### PR TITLE
feat: measure real time-to-first-token in LLM v2 spec

### DIFF
--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -9,9 +9,13 @@ LLM_BENCHMARK_FAMILY = "llm"
 CV_SPEC_NAME = "saib_cv_classification"
 LLM_SPEC_NAME = "saib_llm_generation"
 SPEC_VERSION = "1.0"
+# LLM generation moved to a v2 spec when real time-to-first-token replaced the
+# v1 aggregate-only latency. v2 results carry their own profile/runner hashes and
+# never mix with v1 rows.
+LLM_SPEC_VERSION = "2.0"
 
 CV_RUNNER_ID = "saib.cv.classification.v1"
-LLM_RUNNER_ID = "saib.llm.generation.v1"
+LLM_RUNNER_ID = "saib.llm.generation.v2"
 
 
 def canonical_json(data: Mapping[str, Any]) -> str:
@@ -72,7 +76,7 @@ def build_llm_profile(
     return {
         "benchmark_family": LLM_BENCHMARK_FAMILY,
         "benchmark_spec_name": LLM_SPEC_NAME,
-        "benchmark_spec_version": SPEC_VERSION,
+        "benchmark_spec_version": LLM_SPEC_VERSION,
         "backend_protocol_class": backend,
         "model": model,
         "benchmark_type": benchmark_type,
@@ -82,7 +86,8 @@ def build_llm_profile(
         "concurrency": int(concurrency),
         "request_semantics": "requests_are_completed_generation_calls",
         "warmup_semantics": "not_encoded_in_result",
-        "streaming_policy": "aggregate_token_rates",
+        "streaming_policy": "measure_first_token_latency",
+        "ttft_semantics": "first_generated_token_latency_including_prefill",
         "counting_policy": "prompt_and_generated_tokens_counted_separately",
         "sampling_policy": "implementation_default",
         "precision_policy": compute_precision,
@@ -95,7 +100,7 @@ def build_llm_profile_id(profile: Mapping[str, Any]) -> str:
         f"llm_{profile['backend_protocol_class']}_{profile['model']}_"
         f"{profile['benchmark_type']}_p{profile['prompt_token_target']}_"
         f"g{profile['generated_token_target']}_ctx{profile['context_length']}_"
-        f"c{profile['concurrency']}_v1"
+        f"c{profile['concurrency']}_v2"
     ).lower().replace(" ", "_")
 
 

--- a/simple_ai_benchmarking/llm_inference.py
+++ b/simple_ai_benchmarking/llm_inference.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import json
 import os
 import platform
 import threading
@@ -81,6 +82,7 @@ class LLMBackendClient:
         self._local_lock = threading.Lock()
         self._local_model = None
         self._torch = None
+        self._local_device = None
 
         if self.config.backend == PYTORCH_SIMPLE_TRANSFORMER_BACKEND:
             self._setup_pytorch_simple_transformer()
@@ -93,6 +95,18 @@ class LLMBackendClient:
         if self.config.backend == PYTORCH_SIMPLE_TRANSFORMER_BACKEND:
             return self._generate_pytorch_simple_transformer()
         raise ValueError(f"Unsupported LLM backend: {self.config.backend}")
+
+    def _sync_device(self) -> None:
+        """Block until queued accelerator work has finished so timing is real.
+
+        MPS and CUDA dispatch kernels asynchronously; without a sync the
+        perf_counter delta would under-measure first-token and total latency."""
+        if self._torch is None or self._local_device is None:
+            return
+        if self._local_device.type == "mps":
+            self._torch.mps.synchronize()
+        elif self._local_device.type == "cuda":
+            self._torch.cuda.synchronize()
 
     def _setup_pytorch_simple_transformer(self) -> None:
         import torch
@@ -124,28 +138,58 @@ class LLMBackendClient:
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": self.config.generated_tokens,
             "temperature": 0,
-            "stream": False,
+            "stream": True,
+            "stream_options": {"include_usage": True},
         }
 
+        prompt_tokens = self.config.prompt_tokens
+        generated_tokens = 0
+        time_to_first_token_s = None
+
         start = time.perf_counter()
-        response = self.session.post(
+        with self.session.post(
             url,
             json=payload,
             headers=headers,
             timeout=self.config.timeout_s,
-        )
+            stream=True,
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                if line.startswith("data:"):
+                    line = line[len("data:") :].strip()
+                if line == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                choices = chunk.get("choices") or []
+                if choices:
+                    content = (choices[0].get("delta") or {}).get("content")
+                    if content:
+                        if time_to_first_token_s is None:
+                            time_to_first_token_s = time.perf_counter() - start
+                        generated_tokens += 1
+                usage = chunk.get("usage")
+                if usage:
+                    prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                    generated_tokens = int(
+                        usage.get("completion_tokens", generated_tokens)
+                    )
         duration_s = time.perf_counter() - start
-        response.raise_for_status()
-        data = response.json()
-        usage = data.get("usage", {})
 
         return LLMRequestResult(
             duration_s=duration_s,
-            prompt_tokens=int(usage.get("prompt_tokens", self.config.prompt_tokens)),
-            generated_tokens=int(
-                usage.get("completion_tokens", self.config.generated_tokens)
-            ),
-            time_to_first_token_s=duration_s,
+            prompt_tokens=prompt_tokens,
+            generated_tokens=generated_tokens or self.config.generated_tokens,
+            time_to_first_token_s=time_to_first_token_s
+            if time_to_first_token_s is not None
+            else duration_s,
         )
 
     def _generate_ollama(self, prompt: str) -> LLMRequestResult:
@@ -153,7 +197,7 @@ class LLMBackendClient:
         payload = {
             "model": self.config.model,
             "prompt": prompt,
-            "stream": False,
+            "stream": True,
             "options": {
                 "num_predict": self.config.generated_tokens,
                 "num_ctx": self.config.context_length,
@@ -161,17 +205,42 @@ class LLMBackendClient:
             },
         }
 
+        prompt_tokens = self.config.prompt_tokens
+        generated_tokens = 0
+        time_to_first_token_s = None
+
         start = time.perf_counter()
-        response = self.session.post(url, json=payload, timeout=self.config.timeout_s)
+        with self.session.post(
+            url, json=payload, timeout=self.config.timeout_s, stream=True
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if data.get("response"):
+                    if time_to_first_token_s is None:
+                        time_to_first_token_s = time.perf_counter() - start
+                    generated_tokens += 1
+                if data.get("done"):
+                    generated_tokens = int(data.get("eval_count", generated_tokens))
+                    prompt_tokens = int(
+                        data.get("prompt_eval_count", prompt_tokens)
+                    )
         duration_s = time.perf_counter() - start
-        response.raise_for_status()
-        data = response.json()
 
         return LLMRequestResult(
             duration_s=duration_s,
-            prompt_tokens=int(data.get("prompt_eval_count", self.config.prompt_tokens)),
-            generated_tokens=int(data.get("eval_count", self.config.generated_tokens)),
-            time_to_first_token_s=duration_s,
+            prompt_tokens=prompt_tokens,
+            generated_tokens=generated_tokens or self.config.generated_tokens,
+            time_to_first_token_s=time_to_first_token_s
+            if time_to_first_token_s is not None
+            else duration_s,
         )
 
     def _generate_pytorch_simple_transformer(self) -> LLMRequestResult:
@@ -185,16 +254,28 @@ class LLMBackendClient:
         ).unsqueeze(0)
         input_ids = input_ids % self.config.vocab_size
 
+        generated_tokens = max(1, self.config.generated_tokens)
+
+        # Time the first generated token (prefill + one decode step) separately so
+        # time-to-first-token is a real measurement, not the full-generation latency.
         start = time.perf_counter()
         with self._local_lock:
-            self._local_model.generate(input_ids, self.config.generated_tokens)
+            sequence = self._local_model.generate(input_ids, 1)
+            self._sync_device()
+        time_to_first_token_s = time.perf_counter() - start
+
+        remaining_tokens = generated_tokens - 1
+        if remaining_tokens > 0:
+            with self._local_lock:
+                self._local_model.generate(sequence, remaining_tokens)
+                self._sync_device()
         duration_s = time.perf_counter() - start
 
         return LLMRequestResult(
             duration_s=duration_s,
             prompt_tokens=self.config.prompt_tokens,
-            generated_tokens=self.config.generated_tokens,
-            time_to_first_token_s=duration_s,
+            generated_tokens=generated_tokens,
+            time_to_first_token_s=time_to_first_token_s,
         )
 
 

--- a/simple_ai_benchmarking/llm_results.py
+++ b/simple_ai_benchmarking/llm_results.py
@@ -11,7 +11,7 @@ from simple_ai_benchmarking.benchmark_metadata import (
     LLM_BENCHMARK_FAMILY,
     LLM_RUNNER_ID,
     LLM_SPEC_NAME,
-    SPEC_VERSION,
+    LLM_SPEC_VERSION,
     build_llm_profile,
     build_llm_profile_id,
     build_payload_hash,
@@ -59,7 +59,7 @@ class LLMBenchInfo:
         )
         self.benchmark_family = LLM_BENCHMARK_FAMILY
         self.benchmark_spec_name = LLM_SPEC_NAME
-        self.benchmark_spec_version = SPEC_VERSION
+        self.benchmark_spec_version = LLM_SPEC_VERSION
         self.benchmark_profile_id = build_llm_profile_id(profile)
         self.benchmark_profile_hash = canonical_hash(profile)
         self.benchmark_config_hash = canonical_hash(profile)

--- a/tests/test_llm_inference.py
+++ b/tests/test_llm_inference.py
@@ -10,29 +10,40 @@ from simple_ai_benchmarking.llm_inference import (
 
 
 class FakeResponse:
-    def __init__(self, data):
-        self.data = data
+    def __init__(self, lines):
+        self.lines = lines
 
     def raise_for_status(self):
         pass
 
-    def json(self):
-        return self.data
+    def iter_lines(self):
+        return iter(self.lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
 
 
 class FakeSession:
-    def __init__(self, data):
-        self.data = data
+    def __init__(self, lines):
+        self.lines = lines
         self.calls = []
 
     def post(self, url, **kwargs):
         self.calls.append((url, kwargs))
-        return FakeResponse(self.data)
+        return FakeResponse(self.lines)
 
 
 def test_openai_compatible_backend_posts_chat_completion_request():
     session = FakeSession(
-        {"usage": {"prompt_tokens": 17, "completion_tokens": 23}}
+        [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+            'data: {"choices":[{"delta":{"content":" world"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":17,"completion_tokens":23}}',
+            "data: [DONE]",
+        ]
     )
     config = LLMInferenceConfig(
         backend=OPENAI_COMPATIBLE_BACKEND,
@@ -48,12 +59,20 @@ def test_openai_compatible_backend_posts_chat_completion_request():
     assert session.calls[0][0] == "https://example.test/v1/chat/completions"
     assert session.calls[0][1]["headers"]["Authorization"] == "Bearer token"
     assert session.calls[0][1]["json"]["model"] == "test-model"
+    assert session.calls[0][1]["json"]["stream"] is True
     assert result.prompt_tokens == 17
     assert result.generated_tokens == 23
+    assert 0 < result.time_to_first_token_s <= result.duration_s
 
 
 def test_ollama_backend_posts_generate_request():
-    session = FakeSession({"prompt_eval_count": 11, "eval_count": 19})
+    session = FakeSession(
+        [
+            '{"response":"Hel"}',
+            '{"response":"lo"}',
+            '{"done":true,"eval_count":19,"prompt_eval_count":11}',
+        ]
+    )
     config = LLMInferenceConfig(
         backend=OLLAMA_BACKEND,
         base_url="http://localhost:11434",
@@ -66,12 +85,20 @@ def test_ollama_backend_posts_generate_request():
 
     assert session.calls[0][0] == "http://localhost:11434/api/generate"
     assert session.calls[0][1]["json"]["options"]["num_predict"] == 19
+    assert session.calls[0][1]["json"]["stream"] is True
     assert result.prompt_tokens == 11
     assert result.generated_tokens == 19
+    assert 0 < result.time_to_first_token_s <= result.duration_s
 
 
 def test_llm_inference_benchmark_builds_exportable_result():
-    session = FakeSession({"usage": {"prompt_tokens": 10, "completion_tokens": 20}})
+    session = FakeSession(
+        [
+            'data: {"choices":[{"delta":{"content":"a"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20}}',
+            "data: [DONE]",
+        ]
+    )
     config = LLMInferenceConfig(
         backend=OPENAI_COMPATIBLE_BACKEND,
         base_url="https://example.test",
@@ -144,6 +171,11 @@ def test_pytorch_simple_transformer_backend_builds_result():
     assert result.bench_info.model == "SimpleTransformerLM"
     assert result.bench_info.model_params > 0
     assert result.performance.generated_tokens_per_second > 0
+    assert (
+        0
+        < result.performance.time_to_first_token_s
+        <= result.performance.duration_s
+    )
 
 
 def test_build_config_uses_backend_default_base_urls(monkeypatch):


### PR DESCRIPTION
**Why:** The reported `time_to_first_token_s` was actually full-generation latency — every backend set TTFT equal to the whole request duration, so an M2 Pro run showed a 6.4 s "TTFT" for 256 tokens. There was no real first-token measurement.

**What:**
- pytorch-simple-transformer: time the first generated token (prefill + one decode step) separately, with an explicit MPS/CUDA `synchronize()` so async dispatch doesn't under-measure.
- OpenAI/Ollama backends: stream the response (`stream: True`) and stamp the first content chunk as TTFT.
- Bump LLM to a v2 spec: `saib_llm_generation` 2.0, runner `saib.llm.generation.v2`, profile id `..._v2`, `streaming_policy=measure_first_token_latency` (+ `ttft_semantics`). v2 gets fresh profile/runner hashes so it never mixes with v1 rows.

**Test:** `pytest tests/test_llm_inference.py tests/test_benchmark_metadata.py tests/test_publish.py` (16 passed). Live MPS run: TTFT 0.0062 s vs duration 7.68 s; aggregate token-rate formula unchanged. Pre-existing failures in `test_benchmark_dispatcher`/`test_model_similarity` (TensorFlow not installed) are unrelated.