### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"


### PR DESCRIPTION
**Why:** Cut the 0.6.0 release that ships real LLM time-to-first-token (v2 spec).
**What:**
- Bump `VERSION` to 0.6.0.
**Test:** Version-only change; LLM/metadata/publish suites green on main (#30).