### PR TITLE
feat: model PyTorch LLM concurrency as batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The benchmark performs configurable warmup and measured requests (optionally con
 Common options (see `saib-llm -h` for the full list):
 
 - `--requests` / `--warmup-requests` — number of measured / warmup requests (default `10` / `1`)
-- `--concurrency` — number of concurrent requests (default `1`)
+- `--concurrency` — for HTTP backends (`openai-compatible`, `ollama`), the number of in-flight concurrent requests; for the local `pytorch-simple-transformer` backend, the batch size processed in a single batched forward pass (default `1`)
 - `--prompt-tokens` / `--generated-tokens` — prompt and generation lengths (default `128` / `256`)
 - `--context-length` — model context window (default `4096`)
 - `--device` — torch device for the local backend, e.g. `cpu`, `cuda`, `mps` (default `cpu`)

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -11,8 +11,10 @@ LLM_SPEC_NAME = "saib_llm_generation"
 SPEC_VERSION = "1.0"
 # LLM generation moved to a v2 spec when real time-to-first-token replaced the
 # v1 aggregate-only latency. v2 results carry their own profile/runner hashes and
-# never mix with v1 rows.
-LLM_SPEC_VERSION = "2.0"
+# never mix with v1 rows. Bumped to 2.1 when local-backend concurrency became a
+# batched forward pass (concurrency = batch size) instead of competing threads,
+# changing throughput methodology for the pytorch backend.
+LLM_SPEC_VERSION = "2.1"
 
 CV_RUNNER_ID = "saib.cv.classification.v1"
 LLM_RUNNER_ID = "saib.llm.generation.v2"

--- a/simple_ai_benchmarking/llm_inference.py
+++ b/simple_ai_benchmarking/llm_inference.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import os
 import platform
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -79,7 +78,6 @@ class LLMBackendClient:
     ) -> None:
         self.config = config
         self.session = session or requests.Session()
-        self._local_lock = threading.Lock()
         self._local_model = None
         self._torch = None
         self._local_device = None
@@ -244,14 +242,31 @@ class LLMBackendClient:
         )
 
     def _generate_pytorch_simple_transformer(self) -> LLMRequestResult:
+        return self.generate_pytorch_batch(1)[0]
+
+    def generate_pytorch_batch(self, batch_size: int) -> List[LLMRequestResult]:
+        """Generate ``batch_size`` sequences in a single batched forward pass.
+
+        For local hardware, concurrency is modelled as batch size (like the CV
+        inference workloads), not as competing threads: the accelerator runs the
+        whole batch at once, so this measures real throughput scaling. Every
+        sequence in the batch shares the batch's wall-clock duration, which is
+        what aggregate tokens/s is computed against in ``_build_result``."""
         assert self._torch is not None
         assert self._local_model is not None
+        assert batch_size > 0
 
-        input_ids = self._torch.arange(
-            self.config.prompt_tokens,
-            device=self._local_device,
-            dtype=self._torch.long,
-        ).unsqueeze(0)
+        prompt_tokens = self.config.prompt_tokens
+        input_ids = (
+            self._torch.arange(
+                prompt_tokens,
+                device=self._local_device,
+                dtype=self._torch.long,
+            )
+            .unsqueeze(0)
+            .expand(batch_size, prompt_tokens)
+            .contiguous()
+        )
         input_ids = input_ids % self.config.vocab_size
 
         generated_tokens = max(1, self.config.generated_tokens)
@@ -259,24 +274,25 @@ class LLMBackendClient:
         # Time the first generated token (prefill + one decode step) separately so
         # time-to-first-token is a real measurement, not the full-generation latency.
         start = time.perf_counter()
-        with self._local_lock:
-            sequence = self._local_model.generate(input_ids, 1)
-            self._sync_device()
+        sequence = self._local_model.generate(input_ids, 1)
+        self._sync_device()
         time_to_first_token_s = time.perf_counter() - start
 
         remaining_tokens = generated_tokens - 1
         if remaining_tokens > 0:
-            with self._local_lock:
-                self._local_model.generate(sequence, remaining_tokens)
-                self._sync_device()
+            self._local_model.generate(sequence, remaining_tokens)
+            self._sync_device()
         duration_s = time.perf_counter() - start
 
-        return LLMRequestResult(
-            duration_s=duration_s,
-            prompt_tokens=self.config.prompt_tokens,
-            generated_tokens=generated_tokens,
-            time_to_first_token_s=time_to_first_token_s,
-        )
+        return [
+            LLMRequestResult(
+                duration_s=duration_s,
+                prompt_tokens=prompt_tokens,
+                generated_tokens=generated_tokens,
+                time_to_first_token_s=time_to_first_token_s,
+            )
+            for _ in range(batch_size)
+        ]
 
 
 class LLMInferenceBenchmark:
@@ -320,6 +336,35 @@ class LLMInferenceBenchmark:
             )
 
     def _run_requests(self, prompt: str) -> List[LLMRequestResult]:
+        if self.config.backend == PYTORCH_SIMPLE_TRANSFORMER_BACKEND:
+            return self._run_requests_batched()
+        return self._run_requests_threaded(prompt)
+
+    def _run_requests_batched(self) -> List[LLMRequestResult]:
+        """Local PyTorch path: concurrency is the batch size, not a thread count.
+
+        The requested sequences are processed in batched forward passes of up to
+        ``concurrency`` sequences each (the final batch may be smaller), so the
+        accelerator does the concurrent work instead of competing Python threads."""
+        request_results: List[LLMRequestResult] = []
+        start = time.perf_counter()
+        _print_progress(
+            f"Running measured requests: {self.config.requests} "
+            f"(batched, batch_size={self.config.concurrency})"
+        )
+        remaining = self.config.requests
+        while remaining > 0:
+            batch_size = min(self.config.concurrency, remaining)
+            request_results.extend(self.client.generate_pytorch_batch(batch_size))
+            remaining -= batch_size
+            _print_progress(
+                f"Completed request {len(request_results)}/{self.config.requests}."
+            )
+        self.duration_s = time.perf_counter() - start
+        _print_progress(f"Measured requests completed in {self.duration_s:.3f} s.")
+        return request_results
+
+    def _run_requests_threaded(self, prompt: str) -> List[LLMRequestResult]:
         request_results = []
         start = time.perf_counter()
         _print_progress(f"Running measured requests: {self.config.requests}")
@@ -338,9 +383,8 @@ class LLMInferenceBenchmark:
         return request_results
 
     def _build_result(self, request_results: List[LLMRequestResult]) -> LLMBenchmarkResult:
-        completed_requests = len(request_results)
-        prompt_tokens = self.config.prompt_tokens * completed_requests
-        generated_tokens = self.config.generated_tokens * completed_requests
+        prompt_tokens = sum(result.prompt_tokens for result in request_results)
+        generated_tokens = sum(result.generated_tokens for result in request_results)
         total_tokens = prompt_tokens + generated_tokens
         duration_s = self.duration_s
         ttft_values = [result.time_to_first_token_s for result in request_results]

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.6.0"
+VERSION = "0.6.1"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_llm_inference.py
+++ b/tests/test_llm_inference.py
@@ -178,6 +178,74 @@ def test_pytorch_simple_transformer_backend_builds_result():
     )
 
 
+def test_pytorch_simple_transformer_generate_batch_returns_per_sequence_results():
+    import pytest
+
+    pytest.importorskip("torch")
+    config = LLMInferenceConfig(
+        backend=PYTORCH_SIMPLE_TRANSFORMER_BACKEND,
+        base_url="",
+        model="SimpleTransformerLM",
+        prompt_tokens=4,
+        generated_tokens=3,
+        context_length=8,
+        device="cpu",
+        vocab_size=128,
+        embedding_dim=32,
+        transformer_layers=1,
+        attention_heads=4,
+    )
+    client = LLMBackendClient(config)
+
+    results = client.generate_pytorch_batch(3)
+
+    assert len(results) == 3
+    assert all(r.prompt_tokens == 4 for r in results)
+    assert all(r.generated_tokens == 3 for r in results)
+    # A single batched forward pass: every sequence shares the batch duration.
+    assert len({r.duration_s for r in results}) == 1
+
+
+def test_pytorch_simple_transformer_models_concurrency_as_batch_size():
+    import pytest
+
+    pytest.importorskip("torch")
+    config = LLMInferenceConfig(
+        backend=PYTORCH_SIMPLE_TRANSFORMER_BACKEND,
+        base_url="",
+        model="SimpleTransformerLM",
+        requests=5,
+        warmup_requests=0,
+        concurrency=2,
+        prompt_tokens=4,
+        generated_tokens=2,
+        context_length=8,
+        device="cpu",
+        vocab_size=128,
+        embedding_dim=32,
+        transformer_layers=1,
+        attention_heads=4,
+    )
+    client = LLMBackendClient(config)
+
+    batch_sizes = []
+    original_generate_batch = client.generate_pytorch_batch
+
+    def spy(batch_size):
+        batch_sizes.append(batch_size)
+        return original_generate_batch(batch_size)
+
+    client.generate_pytorch_batch = spy
+    benchmark = LLMInferenceBenchmark(config, client)
+
+    result = benchmark.run()
+
+    # 5 requests with batch size (concurrency) 2 -> batches of 2, 2, 1.
+    assert batch_sizes == [2, 2, 1]
+    assert result.performance.requests == 5
+    assert result.performance.generated_tokens_per_second > 0
+
+
 def test_build_config_uses_backend_default_base_urls(monkeypatch):
     class Args:
         backend = OLLAMA_BACKEND


### PR DESCRIPTION
**Why:** The local `pytorch-simple-transformer` LLM backend faked concurrency with a thread pool serialized by a `threading.Lock`, so it never measured real parallel throughput. For local hardware, concurrency should be batching — exactly how the CV inference workloads run a batch through the model in one forward pass.

**What:**
- Add `LLMBackendClient.generate_pytorch_batch`; route the pytorch backend through batched forward passes where `concurrency` = batch size (final batch may be smaller). Requested sequences are split into batches of up to `concurrency`.
- Remove the thread pool + `threading.Lock` from the local path; keep `ThreadPoolExecutor` only for the HTTP backends (`openai-compatible`, `ollama`), where driving concurrent in-flight requests is the right way to load-test a serving stack.
- Sum measured tokens in `_build_result` instead of multiplying config values (correct now that batch sizes can vary).
- Bump `LLM_SPEC_VERSION` 2.0 → 2.1 so batched-throughput results never silently mix with old threaded v2.0 rows (same profile hash, different methodology at `concurrency>1`).
- Bump package version 0.6.0 → 0.6.1; document the now backend-dependent `--concurrency` in the README.

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_llm_inference.py tests/test_benchmark_metadata.py tests/test_publish.py -q` → 16 passed. New tests: `generate_pytorch_batch` returns one result per sequence sharing a single batch duration; `requests=5, concurrency=2` drives batches of `[2, 2, 1]` (concurrency = batch size) with positive throughput. `python3 -m compileall simple_ai_benchmarking tests` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)