### PR TITLE
refactor: extract shared benchmark result and logging infrastructure

### DIFF
--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -106,6 +106,33 @@ def build_llm_profile_id(profile: Mapping[str, Any]) -> str:
     ).lower().replace(" ", "_")
 
 
+def assign_benchmark_identity(
+    obj: Any,
+    *,
+    family: str,
+    spec_name: str,
+    spec_version: str,
+    runner_id: str,
+    profile: Mapping[str, Any],
+    profile_id: str,
+) -> None:
+    """Populate the shared benchmark_* identity fields on a BenchInfo dataclass.
+
+    Both the CV and LLM BenchInfo variants carry the same eight benchmark_*
+    columns derived the same way (profile/config hash of the profile, runner
+    hash of the runner id). Centralizing it keeps the two __post_init__ hooks in
+    sync instead of duplicating the hashing dance."""
+    profile_hash = canonical_hash(profile)
+    obj.benchmark_family = family
+    obj.benchmark_spec_name = spec_name
+    obj.benchmark_spec_version = spec_version
+    obj.benchmark_profile_id = profile_id
+    obj.benchmark_profile_hash = profile_hash
+    obj.benchmark_config_hash = profile_hash
+    obj.benchmark_runner_id = runner_id
+    obj.benchmark_runner_hash = build_runner_hash(runner_id)
+
+
 def build_runner_hash(runner_id: str) -> str:
     return canonical_hash(
         {

--- a/simple_ai_benchmarking/llm_inference.py
+++ b/simple_ai_benchmarking/llm_inference.py
@@ -2,14 +2,11 @@ import argparse
 import datetime
 import json
 import os
-import platform
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-import cpuinfo
-import psutil
 import requests
 
 from simple_ai_benchmarking.llm_results import (
@@ -18,7 +15,7 @@ from simple_ai_benchmarking.llm_results import (
     LLMBenchmarkResult,
     LLMPerformanceResult,
 )
-from simple_ai_benchmarking.results import HWInfo, SWInfo
+from simple_ai_benchmarking.results import collect_hw_info, collect_sw_info
 
 
 OPENAI_COMPATIBLE_BACKEND = "openai-compatible"
@@ -389,19 +386,12 @@ class LLMInferenceBenchmark:
         duration_s = self.duration_s
         ttft_values = [result.time_to_first_token_s for result in request_results]
 
-        sw_info = SWInfo(
+        sw_info = collect_sw_info(
             ai_framework_name=self.config.backend,
             ai_framework_version=self.config.ai_framework_version,
             ai_framework_extra_info=self.config.ai_framework_extra_info,
-            python_version=platform.python_version(),
-            os_version=platform.platform(aliased=False, terse=False),
         )
-        hw_info = HWInfo(
-            cpu=cpuinfo.get_cpu_info().get("brand_raw", "unknown"),
-            num_cores=os.cpu_count() or 0,
-            ram_gb=psutil.virtual_memory().total / 1e9,
-            accelerator=self.config.accelerator,
-        )
+        hw_info = collect_hw_info(self.config.accelerator)
         bench_info = LLMBenchInfo(
             benchmark_type="inference",
             backend=self.config.backend,

--- a/simple_ai_benchmarking/llm_results.py
+++ b/simple_ai_benchmarking/llm_results.py
@@ -1,10 +1,9 @@
 # Project Name: simple-ai-benchmarking
 # File Name: llm_results.py
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import List
 
-import pandas as pd
 from tabulate import tabulate
 
 from simple_ai_benchmarking.benchmark_metadata import (
@@ -12,13 +11,11 @@ from simple_ai_benchmarking.benchmark_metadata import (
     LLM_RUNNER_ID,
     LLM_SPEC_NAME,
     LLM_SPEC_VERSION,
+    assign_benchmark_identity,
     build_llm_profile,
     build_llm_profile_id,
-    build_payload_hash,
-    build_runner_hash,
-    canonical_hash,
 )
-from simple_ai_benchmarking.results import HWInfo, SWInfo
+from simple_ai_benchmarking.results import BaseBenchmarkLogger, HWInfo, SWInfo
 
 
 @dataclass
@@ -57,14 +54,15 @@ class LLMBenchInfo:
             generated_tokens=self.generated_tokens,
             concurrency=self.concurrency,
         )
-        self.benchmark_family = LLM_BENCHMARK_FAMILY
-        self.benchmark_spec_name = LLM_SPEC_NAME
-        self.benchmark_spec_version = LLM_SPEC_VERSION
-        self.benchmark_profile_id = build_llm_profile_id(profile)
-        self.benchmark_profile_hash = canonical_hash(profile)
-        self.benchmark_config_hash = canonical_hash(profile)
-        self.benchmark_runner_id = LLM_RUNNER_ID
-        self.benchmark_runner_hash = build_runner_hash(LLM_RUNNER_ID)
+        assign_benchmark_identity(
+            self,
+            family=LLM_BENCHMARK_FAMILY,
+            spec_name=LLM_SPEC_NAME,
+            spec_version=LLM_SPEC_VERSION,
+            runner_id=LLM_RUNNER_ID,
+            profile=profile,
+            profile_id=build_llm_profile_id(profile),
+        )
 
 
 @dataclass
@@ -87,29 +85,9 @@ class LLMBenchmarkResult:
     performance: LLMPerformanceResult
 
 
-class LLMBenchmarkLogger:
+class LLMBenchmarkLogger(BaseBenchmarkLogger):
     def __init__(self) -> None:
         self.results: List[LLMBenchmarkResult] = []
-
-    def add_result(self, result: LLMBenchmarkResult) -> None:
-        self.results.append(result)
-
-    def to_dataframe(self) -> pd.DataFrame:
-        flat_dicts = []
-        for result in self.results:
-            flat_dict = {}
-            for key, value in asdict(result).items():
-                if isinstance(value, dict):
-                    for sub_key, sub_value in value.items():
-                        flat_dict[f"{key}_{sub_key}"] = sub_value
-                else:
-                    flat_dict[key] = value
-            flat_dict["bench_info_benchmark_payload_hash"] = build_payload_hash(
-                flat_dict
-            )
-            flat_dicts.append(flat_dict)
-
-        return pd.DataFrame(flat_dicts)
 
     def pretty_print_summary(self) -> None:
         print("\n===== LLM BENCHMARK SUMMARY =====\n")
@@ -147,9 +125,3 @@ class LLMBenchmarkLogger:
             )
 
         print(tabulate(table_data, headers=header, tablefmt="pretty"))
-
-    def export_to_csv(self, file_name: str) -> None:
-        self.to_dataframe().to_csv(file_name, index=False)
-
-    def export_to_excel(self, file_name: str) -> None:
-        self.to_dataframe().to_excel(file_name, index=False)

--- a/simple_ai_benchmarking/results.py
+++ b/simple_ai_benchmarking/results.py
@@ -20,10 +20,14 @@
 from dataclasses import dataclass, field, asdict
 from typing import List
 import sys
+import platform
+import multiprocessing
 
 from loguru import logger
 
 import pandas as pd
+import psutil
+import cpuinfo
 from tabulate import tabulate
 
 from simple_ai_benchmarking.benchmark_metadata import (
@@ -31,11 +35,10 @@ from simple_ai_benchmarking.benchmark_metadata import (
     CV_RUNNER_ID,
     CV_SPEC_NAME,
     SPEC_VERSION,
+    assign_benchmark_identity,
     build_cv_profile,
     build_cv_profile_id,
     build_payload_hash,
-    build_runner_hash,
-    canonical_hash,
 )
 
 
@@ -60,6 +63,31 @@ class HWInfo:
     num_cores: int
     ram_gb: float
     accelerator: str
+
+
+def collect_sw_info(
+    ai_framework_name: str,
+    ai_framework_version: str,
+    ai_framework_extra_info: str,
+) -> SWInfo:
+    """Gather host software info shared by every benchmark family."""
+    return SWInfo(
+        ai_framework_name=ai_framework_name,
+        ai_framework_version=ai_framework_version,
+        ai_framework_extra_info=ai_framework_extra_info,
+        python_version=platform.python_version(),
+        os_version=platform.platform(aliased=False, terse=False),
+    )
+
+
+def collect_hw_info(accelerator: str) -> HWInfo:
+    """Gather host hardware info shared by every benchmark family."""
+    return HWInfo(
+        cpu=cpuinfo.get_cpu_info().get("brand_raw", "unknown"),
+        num_cores=multiprocessing.cpu_count(),
+        ram_gb=psutil.virtual_memory().total / 1e9,
+        accelerator=accelerator,
+    )
 
 
 @dataclass
@@ -113,14 +141,15 @@ class BenchInfo:
             sample_shape=self.sample_shape,
             num_classes=self.num_classes,
         )
-        self.benchmark_family = CV_BENCHMARK_FAMILY
-        self.benchmark_spec_name = CV_SPEC_NAME
-        self.benchmark_spec_version = SPEC_VERSION
-        self.benchmark_profile_id = build_cv_profile_id(profile)
-        self.benchmark_profile_hash = canonical_hash(profile)
-        self.benchmark_config_hash = canonical_hash(profile)
-        self.benchmark_runner_id = CV_RUNNER_ID
-        self.benchmark_runner_hash = build_runner_hash(CV_RUNNER_ID)
+        assign_benchmark_identity(
+            self,
+            family=CV_BENCHMARK_FAMILY,
+            spec_name=CV_SPEC_NAME,
+            spec_version=SPEC_VERSION,
+            runner_id=CV_RUNNER_ID,
+            profile=profile,
+            profile_id=build_cv_profile_id(profile),
+        )
 
 
 @dataclass
@@ -134,7 +163,44 @@ class BenchmarkResult:
         self.performance.update_duration_and_calc_throughput(duration_s)
 
 
-class BenchmarkLogger:
+class BaseBenchmarkLogger:
+    """Shared result collection and export for all benchmark families.
+
+    Holds the family-agnostic machinery: collecting results, flattening nested
+    dataclasses into a dataframe (with the per-row payload hash), and CSV/Excel
+    export. Subclasses add family-specific result averaging and summary tables."""
+
+    def __init__(self) -> None:
+        self.results: list = []
+
+    def add_result(self, result) -> None:
+        self.results.append(result)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        flat_dicts = []
+        for result in self.results:
+            flat_dict = {}
+            for key, value in asdict(result).items():
+                if isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        flat_dict[f"{key}_{sub_key}"] = sub_value
+                else:
+                    flat_dict[key] = value
+            flat_dict["bench_info_benchmark_payload_hash"] = build_payload_hash(
+                flat_dict
+            )
+            flat_dicts.append(flat_dict)
+
+        return pd.DataFrame(flat_dicts)
+
+    def export_to_csv(self, file_name: str) -> None:
+        self.to_dataframe().to_csv(file_name, index=False)
+
+    def export_to_excel(self, file_name: str) -> None:
+        self.to_dataframe().to_excel(file_name, index=False)
+
+
+class BenchmarkLogger(BaseBenchmarkLogger):
 
     def __init__(self) -> None:
         self.results: List[BenchmarkResult] = []
@@ -179,31 +245,6 @@ class BenchmarkLogger:
 
         return avg_result
 
-    def add_result(self, result: BenchmarkResult) -> None:
-        self.results.append(result)
-
-    def to_dataframe(self) -> pd.DataFrame:
-
-        # Convert each BenchmarkResult to a nested dictionary
-        nested_dicts = [asdict(result) for result in self.results]
-
-        # Flatten the nested dictionaries for Pandas
-        flat_dicts = []
-        for nested_dict in nested_dicts:
-            flat_dict = {}
-            for key, value in nested_dict.items():
-                if isinstance(value, dict):
-                    for sub_key, sub_value in value.items():
-                        flat_dict[f"{key}_{sub_key}"] = sub_value
-                else:
-                    flat_dict[key] = value
-            flat_dict["bench_info_benchmark_payload_hash"] = build_payload_hash(
-                flat_dict
-            )
-            flat_dicts.append(flat_dict)
-
-        return pd.DataFrame(flat_dicts)
-
     def pretty_print_summary(self) -> None:
 
         print("\n===== BENCHMARK SUMMARY =====\n")
@@ -243,13 +284,3 @@ class BenchmarkLogger:
             table_data.append(row_data)
 
         print(tabulate(table_data, headers=header, tablefmt="pretty"))
-
-    def export_to_csv(self, file_name: str) -> None:
-
-        df = self.to_dataframe()
-        df.to_csv(file_name, index=False)
-
-    def export_to_excel(self, file_name: str) -> None:
-
-        df = self.to_dataframe()
-        df.to_excel(file_name, index=False)

--- a/simple_ai_benchmarking/workloads/ai_workload.py
+++ b/simple_ai_benchmarking/workloads/ai_workload.py
@@ -18,21 +18,16 @@
 
 
 from abc import abstractmethod, ABC
-import platform
-import multiprocessing
 import datetime
 
 from loguru import logger
 
-import psutil
-import cpuinfo
-
 from simple_ai_benchmarking.results import (
-    SWInfo,
-    HWInfo,
     BenchInfo,
     PerformanceResult,
     BenchmarkResult,
+    collect_sw_info,
+    collect_hw_info,
 )
 from simple_ai_benchmarking.config_structures import AIWorkloadBaseConfig, AIStage
 
@@ -106,20 +101,13 @@ class AIWorkload(ABC):
 
         logger.info(f"Number of model parameters: {self._get_model_parameters()/1e6:.6f} M")
 
-        sw_info = SWInfo(
+        sw_info = collect_sw_info(
             ai_framework_name=self._get_ai_framework_name(),
             ai_framework_version=self._get_ai_framework_version(),
             ai_framework_extra_info=self._get_ai_framework_extra_info(),
-            python_version=platform.python_version(),
-            os_version=platform.platform(aliased=False, terse=False),
         )
 
-        hw_info = HWInfo(
-            cpu=cpuinfo.get_cpu_info()["brand_raw"],
-            num_cores=multiprocessing.cpu_count(),
-            ram_gb=psutil.virtual_memory().total / 1e9,
-            accelerator=self._get_accelerator_info(),
-        )
+        hw_info = collect_hw_info(self._get_accelerator_info())
 
         bench_info = BenchInfo(
             workload_type=self.__class__.__name__,

--- a/tests/test_benchmark_metadata.py
+++ b/tests/test_benchmark_metadata.py
@@ -10,17 +10,44 @@ from simple_ai_benchmarking.llm_results import (
     LLMPerformanceResult,
 )
 from simple_ai_benchmarking.results import (
+    BaseBenchmarkLogger,
     BenchInfo,
     BenchmarkLogger,
     BenchmarkResult,
     HWInfo,
     PerformanceResult,
     SWInfo,
+    collect_hw_info,
+    collect_sw_info,
 )
 
 
 def test_canonical_hash_is_stable_across_dict_ordering():
     assert canonical_hash({"b": 2, "a": 1}) == canonical_hash({"a": 1, "b": 2})
+
+
+def test_cv_and_llm_loggers_share_base_export_machinery():
+    assert issubclass(BenchmarkLogger, BaseBenchmarkLogger)
+    assert issubclass(LLMBenchmarkLogger, BaseBenchmarkLogger)
+
+
+def test_collect_sw_info_populates_host_runtime_fields():
+    sw_info = collect_sw_info("torch", "2.4.0", "cuda")
+
+    assert sw_info.ai_framework_name == "torch"
+    assert sw_info.ai_framework_version == "2.4.0"
+    assert sw_info.ai_framework_extra_info == "cuda"
+    assert sw_info.python_version
+    assert sw_info.os_version
+
+
+def test_collect_hw_info_uses_passed_accelerator_and_host_fields():
+    hw_info = collect_hw_info("NVIDIA RTX 4090")
+
+    assert hw_info.accelerator == "NVIDIA RTX 4090"
+    assert hw_info.cpu
+    assert hw_info.num_cores >= 1
+    assert hw_info.ram_gb > 0
 
 
 def test_cv_profile_hash_changes_for_workload_parameters_only():


### PR DESCRIPTION
**Why:** The LLM feature was added as a parallel silo that duplicated the CV stack — host info gathering, the dataframe/CSV/Excel logger, the result container, and the `benchmark_*` identity hashing all existed twice. This is the first step of unifying the two pipelines onto one engine.

**What:**
- `results.py`: add `collect_sw_info()` / `collect_hw_info()` (shared host info) and `BaseBenchmarkLogger` (shared `add_result` / `to_dataframe` flatten+payload-hash / CSV / Excel). `BenchmarkLogger` now subclasses it, keeping only CV averaging + summary.
- `benchmark_metadata.py`: add `assign_benchmark_identity(...)` — single source for the 8 `benchmark_*` id/hash fields.
- `ai_workload.py`, `llm_inference.py`: use the shared collectors; drop duplicated `cpuinfo`/`psutil`/`platform` gathering and now-unused imports.
- `llm_results.py`: `LLMBenchmarkLogger` subclasses `BaseBenchmarkLogger`; `LLMBenchInfo` uses `assign_benchmark_identity`.

**No behavior change:** the timing path is untouched; profile/spec/runner hashes are byte-identical (LLM `num_cores` now uses `multiprocessing.cpu_count()` to match CV — an equivalent value, not part of the spec/profile hash). No spec or version bump (a bump is planned for the later PR that changes LLM run semantics).

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_llm_inference.py tests/test_benchmark_metadata.py tests/test_publish.py tests/test_ai_workload.py -q` → 21 passed (added logger-inheritance + `collect_*` coverage). Also ran the full CV PyTorch dispatcher end-to-end (all 6 workloads) through the refactored code. `compileall` OK; pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)