### PR TITLE
refactor: extract shared publish skeleton for CV and LLM

### DIFF
--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -268,11 +268,9 @@ def read_csv_and_create_benchmark_dataset(csv_file_path: str, extra_info: str = 
     return benchmark_datasets
 
 
-def parse_arguments():
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Submit benchmark results to the AI Benchmark Database."
-    )
+def build_publish_parser(description: str) -> argparse.ArgumentParser:
+    """Build the argument parser shared by every publish CLI (CV and LLM)."""
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "results_csv_path",
         type=str,
@@ -318,7 +316,14 @@ def parse_arguments():
         default=None,
         help="Extra information to add to the benchmark results.",
     )
-    return parser.parse_args()
+    return parser
+
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    return build_publish_parser(
+        "Submit benchmark results to the AI Benchmark Database."
+    ).parse_args()
 
 
 def handle_token_pw_user(args):
@@ -342,29 +347,36 @@ def handle_token_pw_user(args):
         return api_token
 
 
-def read_and_enrich_benchmark_data(args):
-    """Read and prepare benchmark data from the provided CSV."""
-    benchmark_datasets = read_csv_and_create_benchmark_dataset(
-        args.results_csv_path, args.extra_info
-    )
+def enrich_benchmark_data(benchmark_datasets, data_class, json_file_path, non_interactive):
+    """Round-trip results through an editable JSON file for optional metadata fixes.
 
-    json_file_path = "benchmark_dataset.json"
+    Shared by the CV and LLM publish flows; only the dataclass and json file name
+    differ between families."""
     with open(json_file_path, "w") as f:
-        data = [x.to_dict() for x in benchmark_datasets]
-        json.dump(data, f, indent=4)
+        json.dump([x.to_dict() for x in benchmark_datasets], f, indent=4)
 
-    if not args.non_interactive:
+    if not non_interactive:
         input(
             f"You may now edit the file {json_file_path} to change meta data. Press Enter to continue after reviewing the json ..."
         )
 
     with open(json_file_path, "r") as f:
-        benchmark_datasets = [BenchmarkData(**x) for x in json.load(f)]
+        benchmark_datasets = [data_class(**x) for x in json.load(f)]
 
-    if not args.non_interactive:
+    if not non_interactive:
         benchmark_datasets = prompt_for_updates(benchmark_datasets)
 
     return benchmark_datasets
+
+
+def read_and_enrich_benchmark_data(args):
+    """Read and prepare benchmark data from the provided CSV."""
+    benchmark_datasets = read_csv_and_create_benchmark_dataset(
+        args.results_csv_path, args.extra_info
+    )
+    return enrich_benchmark_data(
+        benchmark_datasets, BenchmarkData, "benchmark_dataset.json", args.non_interactive
+    )
 
 
 def submit_results(benchmark_datasets, args, submit_url, api_token):

--- a/simple_ai_benchmarking/llm_database.py
+++ b/simple_ai_benchmarking/llm_database.py
@@ -1,18 +1,15 @@
 # Project Name: simple-ai-benchmarking
 # File Name: llm_database.py
 
-import argparse
 import csv
-import json
-import os
 from dataclasses import dataclass
 
 from simple_ai_benchmarking.database import (
+    build_publish_parser,
+    enrich_benchmark_data,
     get_git_commit_hash_from_package_version,
     handle_token_pw_user,
-    prompt_for_updates,
-    submit_benchmark_result_token_auth,
-    submit_benchmark_result_user_pw_auth,
+    submit_results,
 )
 from simple_ai_benchmarking.version_and_metadata import REPO_URL, VERSION
 
@@ -128,60 +125,21 @@ def read_csv_and_create_llm_benchmark_dataset(
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(
-        description="Submit LLM benchmark results to the AI Benchmark Database."
-    )
-    parser.add_argument("results_csv_path", type=str)
-    parser.add_argument(
-        "--database-url", type=str, default="https://timoillusion.pythonanywhere.com"
-    )
-    parser.add_argument("--non-interactive", action="store_true", default=False)
-    parser.add_argument("-t", "--token", type=str, default=None)
-    parser.add_argument("-p", "--password", type=str, default=None)
-    parser.add_argument("-u", "--user", type=str, default=None)
-    parser.add_argument("-e", "--extra-info", type=str, default=None)
-    return parser.parse_args()
+    return build_publish_parser(
+        "Submit LLM benchmark results to the AI Benchmark Database."
+    ).parse_args()
 
 
 def read_and_enrich_llm_benchmark_data(args):
     benchmark_datasets = read_csv_and_create_llm_benchmark_dataset(
         args.results_csv_path, args.extra_info
     )
-
-    json_file_path = "llm_benchmark_dataset.json"
-    with open(json_file_path, "w") as f:
-        json.dump([x.to_dict() for x in benchmark_datasets], f, indent=4)
-
-    if not args.non_interactive:
-        input(
-            f"You may now edit the file {json_file_path} to change meta data. Press Enter to continue after reviewing the json ..."
-        )
-
-    with open(json_file_path, "r") as f:
-        benchmark_datasets = [LLMBenchmarkData(**x) for x in json.load(f)]
-
-    if not args.non_interactive:
-        benchmark_datasets = prompt_for_updates(benchmark_datasets)
-
-    return benchmark_datasets
-
-
-def submit_llm_results(benchmark_datasets, args, submit_url, api_token):
-    for benchmark_data in benchmark_datasets:
-        print("Publishing LLM benchmark...")
-
-        if api_token:
-            success = submit_benchmark_result_token_auth(
-                benchmark_data, submit_url, api_token
-            )
-        else:
-            success = submit_benchmark_result_user_pw_auth(
-                benchmark_data, submit_url, args.user, args.password
-            )
-
-        if not success:
-            print("Submission failed. Exiting...")
-            break
+    return enrich_benchmark_data(
+        benchmark_datasets,
+        LLMBenchmarkData,
+        "llm_benchmark_dataset.json",
+        args.non_interactive,
+    )
 
 
 def publish_llm_results_cli():
@@ -190,4 +148,4 @@ def publish_llm_results_cli():
 
     api_token = handle_token_pw_user(args)
     benchmark_datasets = read_and_enrich_llm_benchmark_data(args)
-    submit_llm_results(benchmark_datasets, args, submit_url, api_token)
+    submit_results(benchmark_datasets, args, submit_url, api_token)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -18,9 +18,14 @@
 
 import os
 import unittest
+from dataclasses import dataclass
 from tempfile import NamedTemporaryFile
 
-from simple_ai_benchmarking.database import get_git_commit_hash_from_package_version
+from simple_ai_benchmarking.database import (
+    build_publish_parser,
+    enrich_benchmark_data,
+    get_git_commit_hash_from_package_version,
+)
 from simple_ai_benchmarking.llm_database import read_csv_and_create_llm_benchmark_dataset
 
 
@@ -63,6 +68,41 @@ class TestPublishDatabase(unittest.TestCase):
         self.assertEqual(benchmark_data[0].backend, "llama.cpp")
         self.assertEqual(benchmark_data[0].generated_tokens_per_second, 42.5)
         self.assertEqual(benchmark_data[0].benchmark_spec_name, "saib_llm_generation")
+
+    def test_build_publish_parser_parses_common_args(self):
+        parser = build_publish_parser("desc")
+
+        args = parser.parse_args(
+            ["results.csv", "-t", "tok", "--non-interactive"]
+        )
+
+        self.assertEqual(args.results_csv_path, "results.csv")
+        self.assertEqual(args.token, "tok")
+        self.assertTrue(args.non_interactive)
+        self.assertEqual(
+            args.database_url, "https://timoillusion.pythonanywhere.com"
+        )
+
+    def test_enrich_benchmark_data_roundtrips_non_interactively(self):
+        @dataclass
+        class Tiny:
+            a: int
+            b: str
+
+            def to_dict(self):
+                return self.__dict__
+
+        items = [Tiny(1, "x"), Tiny(2, "y")]
+        with NamedTemporaryFile(mode="w", suffix=".json", delete=False) as json_file:
+            json_path = json_file.name
+        try:
+            result = enrich_benchmark_data(
+                items, Tiny, json_path, non_interactive=True
+            )
+        finally:
+            os.remove(json_path)
+
+        self.assertEqual(result, items)
 
 
 # Entry point for running the tests


### PR DESCRIPTION
**Why:** Second step of unifying the CV and LLM pipelines. `llm_database.py` duplicated the publish CLI — argument parser, the editable-JSON enrich round-trip, and the submit loop — reusing only the auth helpers.

**What:**
- `database.py`: extract `build_publish_parser(description)` (shared CLI args) and `enrich_benchmark_data(datasets, data_class, json_file_path, non_interactive)` (the JSON round-trip + `prompt_for_updates`). `read_and_enrich_benchmark_data` now delegates to it.
- `llm_database.py`: use `build_publish_parser`, `enrich_benchmark_data`, and the existing generic `submit_results`; drop the duplicated `parse_arguments`, `read_and_enrich_llm_benchmark_data` body, and `submit_llm_results`. Net −~40 lines.

**Behavior:** unchanged, except the per-item console line for LLM now reads `Publishing...` (was `Publishing LLM benchmark...`). No data/format change. No spec/version bump.

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_publish.py tests/test_llm_inference.py tests/test_benchmark_metadata.py tests/test_ai_workload.py -q` → 23 passed (added `build_publish_parser` arg-parsing and `enrich_benchmark_data` non-interactive round-trip tests). `compileall` OK; pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)