### PR TITLE
refactor: add local PyTorch generation as an AIWorkload

### DIFF
--- a/simple_ai_benchmarking/config_structures.py
+++ b/simple_ai_benchmarking/config_structures.py
@@ -42,6 +42,7 @@ class AIFramework(Enum):
 class AIStage(Enum):
     INFERENCE = "Inference"
     TRAINING = "Training"
+    GENERATION = "Generation"
 
 
 @dataclass
@@ -109,3 +110,46 @@ class InferenceConfig(AIWorkloadBaseConfig):
 @dataclass
 class TrainingConfig(InferenceConfig):
     epochs: int = 5
+
+
+@dataclass
+class GenerationModelConfig:
+    vocab_size: int = 32000
+    context_length: int = 4096
+    embedding_dim: int = 256
+    attention_heads: int = 4
+    transformer_layers: int = 4
+
+
+@dataclass
+class LLMGenerationConfig:
+    """Config for local generation workloads (sibling to the CV configs).
+
+    Standalone rather than an AIWorkloadBaseConfig subclass: generation has no
+    dataset/batch/num_classes notion. Concurrency is the batch size processed in
+    a single batched forward pass."""
+
+    device_name: str = "cpu"
+    model: str = "SimpleTransformerLM"
+    requests: int = 10
+    warmup_requests: int = 1
+    concurrency: int = 1
+    prompt_tokens: int = 128
+    generated_tokens: int = 256
+    precision: NumericalPrecision = NumericalPrecision.DEFAULT_PRECISION
+    compute_precision: str = "FP32"
+    quantization: str = "none"
+    weight_source: str = "random_weights"
+    accelerator: str = "unknown"
+    ai_framework_version: str = ""
+    ai_framework_extra_info: str = ""
+    model_params: int = 0
+    model_cfg: GenerationModelConfig = field(
+        default_factory=lambda: GenerationModelConfig()
+    )
+
+    def __str__(self):
+        return (
+            f"{self.model} (gen) p{self.prompt_tokens}/g{self.generated_tokens} "
+            f"c{self.concurrency} on {self.device_name}"
+        )

--- a/simple_ai_benchmarking/llm_results.py
+++ b/simple_ai_benchmarking/llm_results.py
@@ -84,6 +84,12 @@ class LLMBenchmarkResult:
     bench_info: LLMBenchInfo
     performance: LLMPerformanceResult
 
+    def update_performance_duration(self, duration_s: float) -> None:
+        # Generation workloads measure their own wall-clock (including device
+        # synchronization) during execution, so the outer benchmark timer is
+        # redundant here and intentionally ignored.
+        pass
+
 
 class LLMBenchmarkLogger(BaseBenchmarkLogger):
     def __init__(self) -> None:

--- a/simple_ai_benchmarking/models/generation_factory.py
+++ b/simple_ai_benchmarking/models/generation_factory.py
@@ -1,0 +1,41 @@
+# Project Name: simple-ai-benchmarking
+# File Name: generation_factory.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from simple_ai_benchmarking.config_structures import GenerationModelConfig
+
+
+class GenerationModelFactory:
+    """Builds local generative models for generation workloads.
+
+    Kept separate from ClassificationModelFactory because a language model is not
+    a classifier (no num_classes / image input shape)."""
+
+    @staticmethod
+    def create_pytorch_model(model_cfg: GenerationModelConfig):
+        from simple_ai_benchmarking.models.pt.simple_transformer_lm import (
+            SimpleTransformerLanguageModel,
+        )
+
+        return SimpleTransformerLanguageModel(
+            vocab_size=model_cfg.vocab_size,
+            context_length=model_cfg.context_length,
+            embedding_dim=model_cfg.embedding_dim,
+            num_heads=model_cfg.attention_heads,
+            num_layers=model_cfg.transformer_layers,
+        )

--- a/simple_ai_benchmarking/workloads/factory.py
+++ b/simple_ai_benchmarking/workloads/factory.py
@@ -23,6 +23,7 @@ from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
 from simple_ai_benchmarking.config_structures import (
     AIWorkloadBaseConfig,
     InferenceConfig,
+    LLMGenerationConfig,
     TrainingConfig,
     AIFramework,
 )
@@ -32,12 +33,28 @@ class WorkloadFactory:
 
     @staticmethod
     def create_workload(workload_cfg: AIWorkloadBaseConfig, framework: AIFramework) -> AIWorkload:
+        if isinstance(workload_cfg, LLMGenerationConfig):
+            return WorkloadFactory._create_generation_workload(workload_cfg, framework)
         if framework is AIFramework.PYTORCH:
             return WorkloadFactory._create_pytorch_workload(workload_cfg)
         elif framework is AIFramework.TENSORFLOW:
             return WorkloadFactory._create_tensorflow_workload(workload_cfg)
         else:
             raise ValueError(f"Framework {framework} not supported")
+
+    @staticmethod
+    def _create_generation_workload(
+        workload_cfg: LLMGenerationConfig, framework: AIFramework
+    ) -> AIWorkload:
+        if framework is AIFramework.PYTORCH:
+            from simple_ai_benchmarking.workloads.llm_workload import (
+                PyTorchLocalGeneration,
+            )
+
+            return PyTorchLocalGeneration(workload_cfg)
+        raise ValueError(
+            f"Generation workloads are not supported for framework {framework}"
+        )
 
     @staticmethod
     def _create_pytorch_workload(workload_cfg: AIWorkloadBaseConfig) -> AIWorkload:

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -1,0 +1,245 @@
+# Project Name: simple-ai-benchmarking
+# File Name: llm_workload.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import datetime
+import time
+from abc import abstractmethod
+from dataclasses import dataclass
+from statistics import mean
+from typing import List, Tuple
+
+from simple_ai_benchmarking.config_structures import AIStage, LLMGenerationConfig
+from simple_ai_benchmarking.llm_results import (
+    LLMBenchInfo,
+    LLMBenchmarkResult,
+    LLMPerformanceResult,
+)
+from simple_ai_benchmarking.results import collect_hw_info, collect_sw_info
+from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
+
+
+@dataclass
+class GenerationRequestResult:
+    prompt_tokens: int
+    generated_tokens: int
+    time_to_first_token_s: float
+
+
+class LLMGenerationWorkload(AIWorkload):
+    """Base for token-generation workloads (sibling family to the CV workloads).
+
+    Generation produces a token-oriented result, so build_result_log is overridden
+    to emit LLMBenchmarkResult. Where the compute happens (local torch, or an HTTP
+    server underneath) is an implementation detail of the subclass hooks."""
+
+    def __init__(self, config: LLMGenerationConfig) -> None:
+        super().__init__(config)
+        self.cfg: LLMGenerationConfig  # for type hinting
+        self._request_results: List[GenerationRequestResult] = []
+        self._duration_s: float = 0.0
+
+    def _prepare_synthetic_dataset(self):
+        return None
+
+    def prepare_execution(self) -> None:
+        pass
+
+    def _warmup(self) -> None:
+        if self.cfg.warmup_requests <= 0:
+            return
+        self._run_warmup()
+
+    def _execute(self) -> None:
+        self._request_results, self._duration_s = self._run_measured()
+
+    def _calculate_iterations(self) -> int:
+        return self.cfg.requests
+
+    def _get_ai_stage(self) -> AIStage:
+        return AIStage.GENERATION
+
+    @abstractmethod
+    def _get_backend(self) -> str:
+        pass
+
+    @abstractmethod
+    def _run_warmup(self) -> None:
+        pass
+
+    @abstractmethod
+    def _run_measured(self) -> Tuple[List[GenerationRequestResult], float]:
+        """Run the measured requests, returning per-request results and wall-clock.
+
+        Generation workloads measure their own duration (including device sync),
+        so it is returned here rather than taken from the outer benchmark timer."""
+
+    def build_result_log(self) -> LLMBenchmarkResult:
+        sw_info = collect_sw_info(
+            self._get_ai_framework_name(),
+            self._get_ai_framework_version(),
+            self._get_ai_framework_extra_info(),
+        )
+        hw_info = collect_hw_info(self._get_accelerator_info())
+
+        prompt_tokens = sum(r.prompt_tokens for r in self._request_results)
+        generated_tokens = sum(r.generated_tokens for r in self._request_results)
+        total_tokens = prompt_tokens + generated_tokens
+        duration_s = self._duration_s
+        ttft = (
+            mean(r.time_to_first_token_s for r in self._request_results)
+            if self._request_results
+            else 0.0
+        )
+
+        bench_info = LLMBenchInfo(
+            benchmark_type="inference",
+            backend=self._get_backend(),
+            model=self.cfg.model,
+            model_params=self.cfg.model_params,
+            compute_precision=self.cfg.compute_precision,
+            quantization=self.cfg.quantization,
+            context_length=self.cfg.model_cfg.context_length,
+            prompt_tokens=self.cfg.prompt_tokens,
+            generated_tokens=self.cfg.generated_tokens,
+            concurrency=self.cfg.concurrency,
+            date=datetime.datetime.now().isoformat(),
+            weight_source=self.cfg.weight_source,
+        )
+        performance = LLMPerformanceResult(
+            requests=self.cfg.requests,
+            duration_s=duration_s,
+            prompt_tokens_per_second=prompt_tokens / duration_s if duration_s else 0.0,
+            generated_tokens_per_second=generated_tokens / duration_s
+            if duration_s
+            else 0.0,
+            total_tokens_per_second=total_tokens / duration_s if duration_s else 0.0,
+            time_to_first_token_s=ttft,
+        )
+        return LLMBenchmarkResult(
+            sw_info=sw_info,
+            hw_info=hw_info,
+            bench_info=bench_info,
+            performance=performance,
+        )
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__} | {self.cfg.model} | {self.cfg.device_name}"
+
+
+class PyTorchLocalGeneration(LLMGenerationWorkload):
+    """Local PyTorch generation: concurrency is the batch size of one forward pass."""
+
+    def setup(self) -> None:
+        import torch
+
+        from simple_ai_benchmarking.models.generation_factory import (
+            GenerationModelFactory,
+        )
+
+        self._torch = torch
+        self._device = torch.device(self.cfg.device_name)
+        self._model = GenerationModelFactory.create_pytorch_model(
+            self.cfg.model_cfg
+        ).to(self._device)
+        self._model.eval()
+        if self.cfg.model_params == 0:
+            self.cfg.model_params = sum(p.numel() for p in self._model.parameters())
+
+    def _sync_device(self) -> None:
+        """Block until queued accelerator work has finished so timing is real."""
+        if self._device.type == "mps":
+            self._torch.mps.synchronize()
+        elif self._device.type == "cuda":
+            self._torch.cuda.synchronize()
+
+    def _generate_batch(self, batch_size: int) -> List[GenerationRequestResult]:
+        prompt_tokens = self.cfg.prompt_tokens
+        input_ids = (
+            self._torch.arange(
+                prompt_tokens, device=self._device, dtype=self._torch.long
+            )
+            .unsqueeze(0)
+            .expand(batch_size, prompt_tokens)
+            .contiguous()
+        )
+        input_ids = input_ids % self.cfg.model_cfg.vocab_size
+
+        generated_tokens = max(1, self.cfg.generated_tokens)
+
+        # Time the first generated token (prefill + one decode step) separately so
+        # time-to-first-token is a real measurement, not full-generation latency.
+        start = time.perf_counter()
+        sequence = self._model.generate(input_ids, 1)
+        self._sync_device()
+        time_to_first_token_s = time.perf_counter() - start
+
+        remaining_tokens = generated_tokens - 1
+        if remaining_tokens > 0:
+            self._model.generate(sequence, remaining_tokens)
+            self._sync_device()
+
+        return [
+            GenerationRequestResult(
+                prompt_tokens=prompt_tokens,
+                generated_tokens=generated_tokens,
+                time_to_first_token_s=time_to_first_token_s,
+            )
+            for _ in range(batch_size)
+        ]
+
+    def _run_warmup(self) -> None:
+        for _ in range(self.cfg.warmup_requests):
+            self._generate_batch(self.cfg.concurrency)
+
+    def _run_measured(self) -> Tuple[List[GenerationRequestResult], float]:
+        request_results: List[GenerationRequestResult] = []
+        start = time.perf_counter()
+        remaining = self.cfg.requests
+        while remaining > 0:
+            batch_size = min(self.cfg.concurrency, remaining)
+            request_results.extend(self._generate_batch(batch_size))
+            remaining -= batch_size
+        duration_s = time.perf_counter() - start
+        return request_results, duration_s
+
+    def _get_backend(self) -> str:
+        return "pytorch-simple-transformer"
+
+    def _get_ai_framework_name(self) -> str:
+        return "pytorch-simple-transformer"
+
+    def _get_ai_framework_version(self) -> str:
+        return self.cfg.ai_framework_version or self._torch.__version__
+
+    def _get_ai_framework_extra_info(self) -> str:
+        return self.cfg.ai_framework_extra_info or self.cfg.device_name
+
+    def _get_accelerator_info(self) -> str:
+        if self.cfg.accelerator != "unknown":
+            return self.cfg.accelerator
+        if self.cfg.device_name.startswith("cuda") and self._torch.cuda.is_available():
+            return self._torch.cuda.get_device_name(None)
+        if self.cfg.device_name == "mps":
+            return "Apple MPS"
+        return "CPU"
+
+    def _get_model_parameters(self) -> int:
+        return self.cfg.model_params or sum(
+            p.numel() for p in self._model.parameters()
+        )

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -1,0 +1,108 @@
+import pytest
+
+from simple_ai_benchmarking.config_structures import (
+    AIFramework,
+    AIStage,
+    GenerationModelConfig,
+    LLMGenerationConfig,
+)
+from simple_ai_benchmarking.workloads.factory import WorkloadFactory
+
+
+def _tiny_config(**overrides) -> LLMGenerationConfig:
+    cfg = LLMGenerationConfig(
+        device_name="cpu",
+        model="SimpleTransformerLM",
+        requests=4,
+        warmup_requests=0,
+        concurrency=2,
+        prompt_tokens=4,
+        generated_tokens=2,
+        model_cfg=GenerationModelConfig(
+            vocab_size=128,
+            context_length=8,
+            embedding_dim=32,
+            attention_heads=4,
+            transformer_layers=1,
+        ),
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def test_factory_builds_pytorch_generation_workload():
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.workloads.llm_workload import PyTorchLocalGeneration
+
+    workload = WorkloadFactory.create_workload(_tiny_config(), AIFramework.PYTORCH)
+
+    assert isinstance(workload, PyTorchLocalGeneration)
+    assert workload._get_ai_stage() is AIStage.GENERATION
+
+
+def test_generation_workload_runs_lifecycle_and_builds_result():
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.workloads.llm_workload import PyTorchLocalGeneration
+
+    workload = PyTorchLocalGeneration(_tiny_config(warmup_requests=1))
+    workload.setup()
+    workload.warmup()
+    workload.prepare_execution()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert result.bench_info.backend == "pytorch-simple-transformer"
+    assert result.bench_info.model == "SimpleTransformerLM"
+    assert result.bench_info.concurrency == 2
+    assert result.bench_info.model_params > 0
+    assert result.performance.requests == 4
+    assert result.performance.generated_tokens_per_second > 0
+    assert 0 < result.performance.time_to_first_token_s <= result.performance.duration_s
+
+
+def test_generation_concurrency_is_batch_size():
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.workloads.llm_workload import (
+        GenerationRequestResult,
+        PyTorchLocalGeneration,
+    )
+
+    workload = PyTorchLocalGeneration(_tiny_config(requests=5, concurrency=2))
+    workload.setup()
+
+    batch_sizes = []
+    original_generate_batch = workload._generate_batch
+
+    def spy(batch_size):
+        batch_sizes.append(batch_size)
+        return original_generate_batch(batch_size)
+
+    workload._generate_batch = spy
+    request_results, duration_s = workload._run_measured()
+
+    # 5 requests with batch size (concurrency) 2 -> batches of 2, 2, 1.
+    assert batch_sizes == [2, 2, 1]
+    assert len(request_results) == 5
+    assert all(isinstance(r, GenerationRequestResult) for r in request_results)
+    assert duration_s > 0
+
+
+def test_generation_workload_result_is_exportable():
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.llm_results import LLMBenchmarkLogger
+    from simple_ai_benchmarking.workloads.llm_workload import PyTorchLocalGeneration
+
+    workload = PyTorchLocalGeneration(_tiny_config())
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    logger = LLMBenchmarkLogger()
+    logger.add_result(result)
+    row = logger.to_dataframe().iloc[0].to_dict()
+
+    assert row["bench_info_benchmark_family"] == "llm"
+    assert row["bench_info_benchmark_spec_version"] == "2.1"
+    assert row["bench_info_benchmark_payload_hash"]


### PR DESCRIPTION
**Why:** Third step of unifying the LLM feature with the CV stack. This introduces a generation workload family under the existing `AIWorkload` contract so local LLM generation can reuse the same lifecycle, result types, logger, and metadata instead of the parallel silo in `llm_inference.py`.

**What (purely additive):**
- `config_structures.py`: `GenerationModelConfig` + `LLMGenerationConfig` (standalone — generation has no dataset/batch/num_classes; concurrency = batch size) and `AIStage.GENERATION`.
- `models/generation_factory.py`: `GenerationModelFactory` builds the local transformer (a LM is not a classifier, so it stays out of `ClassificationModelFactory`).
- `workloads/llm_workload.py`: `LLMGenerationWorkload` base (overrides `build_result_log` to emit `LLMBenchmarkResult` via the shared `collect_*`) and `PyTorchLocalGeneration` (batched generation ported from the silo, self-timed including device sync).
- `workloads/factory.py`: `WorkloadFactory` dispatches `LLMGenerationConfig`.
- `llm_results.py`: `LLMBenchmarkResult` gains a no-op `update_performance_duration` for `benchmark()` compatibility.

**No live behavior change / no version bump:** the `saib-llm` CLI is untouched and still uses the existing path. Wiring through `process_workloads` (repetitions + process isolation + averaging), the CLI cutover, silo deletion, and the `0.6.1 → 0.7.0` bump land in the final PR.

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_llm_workload.py tests/test_llm_inference.py tests/test_benchmark_metadata.py -q` → 21 passed. New `test_llm_workload.py` covers factory dispatch, the full setup/warmup/execute/build_result_log lifecycle, concurrency-as-batch-size (`requests=5, concurrency=2` → batches `[2,2,1]`), and exportable result (family `llm`, spec `2.1`, payload hash). Also ran the workload end-to-end through `benchmark.benchmark()`. `compileall` OK; pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)