### PR TITLE
refactor: add HTTP generation workloads (OpenAI-compatible, Ollama)

### DIFF
--- a/simple_ai_benchmarking/config_structures.py
+++ b/simple_ai_benchmarking/config_structures.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Tuple, Sequence
+from typing import Optional, Tuple, Sequence
 from enum import Enum
 from dataclasses import dataclass, field
 
@@ -123,12 +123,16 @@ class GenerationModelConfig:
 
 @dataclass
 class LLMGenerationConfig:
-    """Config for local generation workloads (sibling to the CV configs).
+    """Config for generation workloads (sibling to the CV configs).
 
     Standalone rather than an AIWorkloadBaseConfig subclass: generation has no
-    dataset/batch/num_classes notion. Concurrency is the batch size processed in
-    a single batched forward pass."""
+    dataset/batch/num_classes notion. `backend` selects the workload (local
+    pytorch transformer vs an HTTP serving backend). For the local backend
+    concurrency is the batch size of a single forward pass; for HTTP backends it
+    is the number of in-flight concurrent requests. `model_cfg`/`device_name`
+    apply to the local backend; `base_url`/`api_key`/`timeout_s` apply to HTTP."""
 
+    backend: str = "pytorch-simple-transformer"
     device_name: str = "cpu"
     model: str = "SimpleTransformerLM"
     requests: int = 10
@@ -136,6 +140,7 @@ class LLMGenerationConfig:
     concurrency: int = 1
     prompt_tokens: int = 128
     generated_tokens: int = 256
+    context_length: int = 4096
     precision: NumericalPrecision = NumericalPrecision.DEFAULT_PRECISION
     compute_precision: str = "FP32"
     quantization: str = "none"
@@ -144,12 +149,15 @@ class LLMGenerationConfig:
     ai_framework_version: str = ""
     ai_framework_extra_info: str = ""
     model_params: int = 0
+    base_url: str = ""
+    api_key: Optional[str] = None
+    timeout_s: float = 120.0
     model_cfg: GenerationModelConfig = field(
         default_factory=lambda: GenerationModelConfig()
     )
 
     def __str__(self):
         return (
-            f"{self.model} (gen) p{self.prompt_tokens}/g{self.generated_tokens} "
-            f"c{self.concurrency} on {self.device_name}"
+            f"{self.model} (gen/{self.backend}) "
+            f"p{self.prompt_tokens}/g{self.generated_tokens} c{self.concurrency}"
         )

--- a/simple_ai_benchmarking/workloads/factory.py
+++ b/simple_ai_benchmarking/workloads/factory.py
@@ -46,15 +46,27 @@ class WorkloadFactory:
     def _create_generation_workload(
         workload_cfg: LLMGenerationConfig, framework: AIFramework
     ) -> AIWorkload:
-        if framework is AIFramework.PYTORCH:
-            from simple_ai_benchmarking.workloads.llm_workload import (
-                PyTorchLocalGeneration,
-            )
-
-            return PyTorchLocalGeneration(workload_cfg)
-        raise ValueError(
-            f"Generation workloads are not supported for framework {framework}"
+        from simple_ai_benchmarking.workloads.llm_workload import (
+            OLLAMA_BACKEND,
+            OPENAI_COMPATIBLE_BACKEND,
+            PYTORCH_GENERATION_BACKEND,
+            OllamaGeneration,
+            OpenAICompatibleGeneration,
+            PyTorchLocalGeneration,
         )
+
+        backend = workload_cfg.backend
+        if backend == OPENAI_COMPATIBLE_BACKEND:
+            return OpenAICompatibleGeneration(workload_cfg)
+        if backend == OLLAMA_BACKEND:
+            return OllamaGeneration(workload_cfg)
+        if backend == PYTORCH_GENERATION_BACKEND:
+            if framework is AIFramework.PYTORCH:
+                return PyTorchLocalGeneration(workload_cfg)
+            raise ValueError(
+                f"Local generation backend requires PyTorch, got {framework}"
+            )
+        raise ValueError(f"Unsupported generation backend: {backend}")
 
     @staticmethod
     def _create_pytorch_workload(workload_cfg: AIWorkloadBaseConfig) -> AIWorkload:

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -18,8 +18,10 @@
 
 
 import datetime
+import json
 import time
 from abc import abstractmethod
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from statistics import mean
 from typing import List, Tuple
@@ -32,6 +34,11 @@ from simple_ai_benchmarking.llm_results import (
 )
 from simple_ai_benchmarking.results import collect_hw_info, collect_sw_info
 from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
+
+
+PYTORCH_GENERATION_BACKEND = "pytorch-simple-transformer"
+OPENAI_COMPATIBLE_BACKEND = "openai-compatible"
+OLLAMA_BACKEND = "ollama"
 
 
 @dataclass
@@ -114,7 +121,7 @@ class LLMGenerationWorkload(AIWorkload):
             model_params=self.cfg.model_params,
             compute_precision=self.cfg.compute_precision,
             quantization=self.cfg.quantization,
-            context_length=self.cfg.model_cfg.context_length,
+            context_length=self.cfg.context_length,
             prompt_tokens=self.cfg.prompt_tokens,
             generated_tokens=self.cfg.generated_tokens,
             concurrency=self.cfg.concurrency,
@@ -154,6 +161,8 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
 
         self._torch = torch
         self._device = torch.device(self.cfg.device_name)
+        # Keep the model context window consistent with the recorded one.
+        self.cfg.model_cfg.context_length = self.cfg.context_length
         self._model = GenerationModelFactory.create_pytorch_model(
             self.cfg.model_cfg
         ).to(self._device)
@@ -219,10 +228,10 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
         return request_results, duration_s
 
     def _get_backend(self) -> str:
-        return "pytorch-simple-transformer"
+        return PYTORCH_GENERATION_BACKEND
 
     def _get_ai_framework_name(self) -> str:
-        return "pytorch-simple-transformer"
+        return PYTORCH_GENERATION_BACKEND
 
     def _get_ai_framework_version(self) -> str:
         return self.cfg.ai_framework_version or self._torch.__version__
@@ -242,4 +251,185 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
     def _get_model_parameters(self) -> int:
         return self.cfg.model_params or sum(
             p.numel() for p in self._model.parameters()
+        )
+
+
+class HTTPGenerationWorkload(LLMGenerationWorkload):
+    """Generation against an HTTP serving backend (which may run locally).
+
+    Concurrency here is the number of in-flight concurrent requests: the serving
+    stack does its own (server-side) batching, so this load-tests the endpoint."""
+
+    def setup(self) -> None:
+        import requests
+
+        if getattr(self, "_session", None) is None:
+            self._session = requests.Session()
+
+    def _build_prompt(self) -> str:
+        # Roughly one token per simple word for backend-independent prompt targets.
+        return " ".join(["benchmark"] * max(1, self.cfg.prompt_tokens))
+
+    def _run_warmup(self) -> None:
+        prompt = self._build_prompt()
+        for _ in range(self.cfg.warmup_requests):
+            self._generate_one(prompt)
+
+    def _run_measured(self) -> Tuple[List[GenerationRequestResult], float]:
+        prompt = self._build_prompt()
+        request_results: List[GenerationRequestResult] = []
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=self.cfg.concurrency) as executor:
+            futures = [
+                executor.submit(self._generate_one, prompt)
+                for _ in range(self.cfg.requests)
+            ]
+            for future in as_completed(futures):
+                request_results.append(future.result())
+        duration_s = time.perf_counter() - start
+        return request_results, duration_s
+
+    @abstractmethod
+    def _generate_one(self, prompt: str) -> GenerationRequestResult:
+        pass
+
+    def _get_ai_framework_version(self) -> str:
+        return self.cfg.ai_framework_version
+
+    def _get_ai_framework_extra_info(self) -> str:
+        return self.cfg.ai_framework_extra_info
+
+    def _get_accelerator_info(self) -> str:
+        return self.cfg.accelerator
+
+    def _get_model_parameters(self) -> int:
+        return self.cfg.model_params
+
+
+class OpenAICompatibleGeneration(HTTPGenerationWorkload):
+
+    def _get_backend(self) -> str:
+        return OPENAI_COMPATIBLE_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return OPENAI_COMPATIBLE_BACKEND
+
+    def _generate_one(self, prompt: str) -> GenerationRequestResult:
+        url = self.cfg.base_url.rstrip("/") + "/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.cfg.api_key:
+            headers["Authorization"] = f"Bearer {self.cfg.api_key}"
+        payload = {
+            "model": self.cfg.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.cfg.generated_tokens,
+            "temperature": 0,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+
+        prompt_tokens = self.cfg.prompt_tokens
+        generated_tokens = 0
+        time_to_first_token_s = None
+
+        start = time.perf_counter()
+        with self._session.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=self.cfg.timeout_s,
+            stream=True,
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                if line.startswith("data:"):
+                    line = line[len("data:") :].strip()
+                if line == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                choices = chunk.get("choices") or []
+                if choices:
+                    content = (choices[0].get("delta") or {}).get("content")
+                    if content:
+                        if time_to_first_token_s is None:
+                            time_to_first_token_s = time.perf_counter() - start
+                        generated_tokens += 1
+                usage = chunk.get("usage")
+                if usage:
+                    prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                    generated_tokens = int(
+                        usage.get("completion_tokens", generated_tokens)
+                    )
+        duration_s = time.perf_counter() - start
+
+        return GenerationRequestResult(
+            prompt_tokens=prompt_tokens,
+            generated_tokens=generated_tokens or self.cfg.generated_tokens,
+            time_to_first_token_s=time_to_first_token_s
+            if time_to_first_token_s is not None
+            else duration_s,
+        )
+
+
+class OllamaGeneration(HTTPGenerationWorkload):
+
+    def _get_backend(self) -> str:
+        return OLLAMA_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return OLLAMA_BACKEND
+
+    def _generate_one(self, prompt: str) -> GenerationRequestResult:
+        url = self.cfg.base_url.rstrip("/") + "/api/generate"
+        payload = {
+            "model": self.cfg.model,
+            "prompt": prompt,
+            "stream": True,
+            "options": {
+                "num_predict": self.cfg.generated_tokens,
+                "num_ctx": self.cfg.context_length,
+                "temperature": 0,
+            },
+        }
+
+        prompt_tokens = self.cfg.prompt_tokens
+        generated_tokens = 0
+        time_to_first_token_s = None
+
+        start = time.perf_counter()
+        with self._session.post(
+            url, json=payload, timeout=self.cfg.timeout_s, stream=True
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if data.get("response"):
+                    if time_to_first_token_s is None:
+                        time_to_first_token_s = time.perf_counter() - start
+                    generated_tokens += 1
+                if data.get("done"):
+                    generated_tokens = int(data.get("eval_count", generated_tokens))
+                    prompt_tokens = int(data.get("prompt_eval_count", prompt_tokens))
+        duration_s = time.perf_counter() - start
+
+        return GenerationRequestResult(
+            prompt_tokens=prompt_tokens,
+            generated_tokens=generated_tokens or self.cfg.generated_tokens,
+            time_to_first_token_s=time_to_first_token_s
+            if time_to_first_token_s is not None
+            else duration_s,
         )

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -7,6 +7,39 @@ from simple_ai_benchmarking.config_structures import (
     LLMGenerationConfig,
 )
 from simple_ai_benchmarking.workloads.factory import WorkloadFactory
+from simple_ai_benchmarking.workloads.llm_workload import (
+    OLLAMA_BACKEND,
+    OPENAI_COMPATIBLE_BACKEND,
+    OllamaGeneration,
+    OpenAICompatibleGeneration,
+)
+
+
+class FakeResponse:
+    def __init__(self, lines):
+        self.lines = lines
+
+    def raise_for_status(self):
+        pass
+
+    def iter_lines(self):
+        return iter(self.lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class FakeSession:
+    def __init__(self, lines):
+        self.lines = lines
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return FakeResponse(self.lines)
 
 
 def _tiny_config(**overrides) -> LLMGenerationConfig:
@@ -86,6 +119,84 @@ def test_generation_concurrency_is_batch_size():
     assert len(request_results) == 5
     assert all(isinstance(r, GenerationRequestResult) for r in request_results)
     assert duration_s > 0
+
+
+def test_factory_dispatches_http_backends_without_torch():
+    openai_cfg = LLMGenerationConfig(
+        backend=OPENAI_COMPATIBLE_BACKEND, base_url="https://example.test"
+    )
+    ollama_cfg = LLMGenerationConfig(
+        backend=OLLAMA_BACKEND, base_url="http://localhost:11434"
+    )
+
+    openai_workload = WorkloadFactory.create_workload(openai_cfg, AIFramework.PYTORCH)
+    ollama_workload = WorkloadFactory.create_workload(ollama_cfg, AIFramework.PYTORCH)
+
+    assert isinstance(openai_workload, OpenAICompatibleGeneration)
+    assert isinstance(ollama_workload, OllamaGeneration)
+
+
+def test_openai_compatible_generation_workload_streams_and_counts_tokens():
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="test-model",
+            api_key="token",
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=23,
+        )
+    )
+    workload._session = FakeSession(
+        [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+            'data: {"choices":[{"delta":{"content":" world"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":17,"completion_tokens":23}}',
+            "data: [DONE]",
+        ]
+    )
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert workload._session.calls[0][0] == "https://example.test/v1/chat/completions"
+    assert workload._session.calls[0][1]["headers"]["Authorization"] == "Bearer token"
+    assert result.bench_info.backend == OPENAI_COMPATIBLE_BACKEND
+    assert result.performance.generated_tokens_per_second > 0
+    assert 0 < result.performance.time_to_first_token_s <= result.performance.duration_s
+
+
+def test_ollama_generation_workload_streams_and_counts_tokens():
+    workload = OllamaGeneration(
+        LLMGenerationConfig(
+            backend=OLLAMA_BACKEND,
+            base_url="http://localhost:11434",
+            model="llama3",
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=19,
+        )
+    )
+    workload._session = FakeSession(
+        [
+            '{"response":"Hel"}',
+            '{"response":"lo"}',
+            '{"done":true,"eval_count":19,"prompt_eval_count":11}',
+        ]
+    )
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert workload._session.calls[0][0] == "http://localhost:11434/api/generate"
+    assert workload._session.calls[0][1]["json"]["options"]["num_predict"] == 19
+    assert result.bench_info.backend == OLLAMA_BACKEND
+    assert result.performance.generated_tokens_per_second > 0
 
 
 def test_generation_workload_result_is_exportable():


### PR DESCRIPTION
**Why:** Fourth step of unifying the LLM feature. Bring the serving-backend benchmarks into the generation workload family — an HTTP backend is just a workload that uses HTTP underneath, sharing the same lifecycle, result types, logger, and metadata as the local PyTorch one. (Per design: HTTP backends can be local too, so they are not labelled remote.)

**What (still additive):**
- `workloads/llm_workload.py`: `HTTPGenerationWorkload` base — builds a `requests.Session`, drives concurrency as in-flight threaded requests (the server does its own batching). `OpenAICompatibleGeneration` and `OllamaGeneration` subclasses port the streaming token-parse from the silo, returning per-request token counts + TTFT.
- `config_structures.py`: `LLMGenerationConfig` gains `backend` / `base_url` / `api_key` / `timeout_s` / `context_length` (top-level, used by all backends).
- `workloads/factory.py`: `WorkloadFactory` dispatches by `backend` (pytorch / openai-compatible / ollama).

**No live behavior change / no version bump:** the `saib-llm` CLI is untouched. The CLI cutover, `process_workloads` wiring (repetitions/isolation/averaging), silo deletion, and `0.6.1 → 0.7.0` land in the final PR.

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_llm_workload.py tests/test_llm_inference.py tests/test_benchmark_metadata.py tests/test_publish.py -q` → 28 passed. New tests cover factory dispatch for both HTTP backends (no torch needed) and the streaming token/TTFT parse via a fake session (mirroring the existing backend tests). `compileall` OK; pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)