### PR TITLE
feat: make saib-llm runnable with defaults; clearer publish errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ I develop this application in my free time as a hobby.
 
 ## LLM Inference Benchmarking
 
-In addition to the vision/CNN workloads, SAIB can benchmark large language model (LLM) inference and report token throughput. Run it with the `saib-llm` entry point:
+In addition to the vision/CNN workloads, SAIB can benchmark large language model (LLM) inference and report token throughput. Run it with the `saib-llm` entry point. With no arguments it runs a self-contained local PyTorch transformer benchmark (no server or model weights required), just like `saib-pt` runs sensible defaults:
 
 ```bash
-saib-llm --backend ollama --model llama3
+saib-llm
 ```
 
 Three backends are supported:
 
-- `openai-compatible` (default) — benchmark any server exposing the OpenAI `/v1/chat/completions` API (e.g. vLLM, llama.cpp server, LM Studio, OpenAI itself):
+- `openai-compatible` — benchmark any server exposing the OpenAI `/v1/chat/completions` API (e.g. vLLM, llama.cpp server, LM Studio, OpenAI itself):
 
   ```bash
   saib-llm --backend openai-compatible --base-url http://localhost:8000 --model my-model --api-key-env OPENAI_API_KEY

--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -215,6 +215,17 @@ def read_csv_and_create_benchmark_dataset(csv_file_path: str, extra_info: str = 
     benchmark_datasets = []
     with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
+        fieldnames = reader.fieldnames or []
+        if "bench_info_workload_type" not in fieldnames:
+            if "bench_info_backend" in fieldnames:
+                raise ValueError(
+                    f"{csv_file_path} looks like an LLM results CSV "
+                    "(no 'bench_info_workload_type' column). Use 'saib-pub-llm' to publish LLM results."
+                )
+            raise ValueError(
+                f"{csv_file_path} is missing the required 'bench_info_workload_type' "
+                "column; is this a SAIB CV results CSV?"
+            )
         for row in reader:
 
             if "training" in row["bench_info_workload_type"].lower():

--- a/simple_ai_benchmarking/llm_database.py
+++ b/simple_ai_benchmarking/llm_database.py
@@ -64,6 +64,17 @@ def read_csv_and_create_llm_benchmark_dataset(
     benchmark_datasets = []
     with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
+        fieldnames = reader.fieldnames or []
+        if "bench_info_backend" not in fieldnames:
+            if "bench_info_workload_type" in fieldnames:
+                raise ValueError(
+                    f"{csv_file_path} looks like a CV results CSV "
+                    "(no 'bench_info_backend' column). Use 'saib-pub' to publish CV results."
+                )
+            raise ValueError(
+                f"{csv_file_path} is missing the required 'bench_info_backend' "
+                "column; is this a SAIB LLM results CSV?"
+            )
         for row in reader:
             if extra_info is None:
                 row_extra_info = row["sw_info_ai_framework_extra_info"]

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -46,10 +46,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         choices=SUPPORTED_LLM_BACKENDS,
-        default=OPENAI_COMPATIBLE_BACKEND,
+        default=PYTORCH_GENERATION_BACKEND,
     )
     parser.add_argument("--base-url", default=None)
-    parser.add_argument("--model", required=True)
+    parser.add_argument("--model", default="SimpleTransformerLM")
     parser.add_argument("--requests", type=int, default=10)
     parser.add_argument("--warmup-requests", type=int, default=1)
     parser.add_argument("--repetitions", type=int, default=3)
@@ -67,7 +67,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--ai-framework-extra-info", default="")
     parser.add_argument("--accelerator", default="unknown")
     parser.add_argument("--weight-source", default="")
-    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--device", default=None)
     parser.add_argument("--vocab-size", type=int, default=32000)
     parser.add_argument("--embedding-dim", type=int, default=256)
     parser.add_argument("--transformer-layers", type=int, default=4)
@@ -91,6 +91,17 @@ def build_generation_config_from_args(
     if api_key is None and args.api_key_env:
         api_key = os.environ.get(args.api_key_env)
 
+    # Default to the best local device (cuda/mps/cpu), matching how the CV
+    # benchmarks pick their device, unless one was explicitly requested.
+    device_name = args.device
+    if device_name is None:
+        if args.backend == PYTORCH_GENERATION_BACKEND:
+            from simple_ai_benchmarking.config_pt_tf import get_device_name_pytorch
+
+            device_name = get_device_name_pytorch()
+        else:
+            device_name = "cpu"
+
     ai_framework_version = args.ai_framework_version
     ai_framework_extra_info = args.ai_framework_extra_info
     accelerator = args.accelerator
@@ -99,14 +110,14 @@ def build_generation_config_from_args(
         import torch
 
         ai_framework_version = ai_framework_version or torch.__version__
-        ai_framework_extra_info = ai_framework_extra_info or args.device
+        ai_framework_extra_info = ai_framework_extra_info or device_name
         compute_precision = args.compute_precision or "FP32"
         quantization = args.quantization or "none"
         weight_source = weight_source or "random_weights"
         if accelerator == "unknown":
-            if args.device.startswith("cuda") and torch.cuda.is_available():
+            if device_name.startswith("cuda") and torch.cuda.is_available():
                 accelerator = torch.cuda.get_device_name(None)
-            elif args.device == "mps":
+            elif device_name == "mps":
                 accelerator = "Apple MPS"
             else:
                 accelerator = "CPU"
@@ -116,7 +127,7 @@ def build_generation_config_from_args(
 
     return LLMGenerationConfig(
         backend=args.backend,
-        device_name=args.device,
+        device_name=device_name,
         model=args.model,
         requests=args.requests,
         warmup_requests=args.warmup_requests,

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.7.0"
+VERSION = "0.7.1"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -2,11 +2,32 @@ import argparse
 
 from simple_ai_benchmarking.llm_generation import (
     build_generation_config_from_args,
+    parse_arguments,
 )
 from simple_ai_benchmarking.workloads.llm_workload import (
     OLLAMA_BACKEND,
     PYTORCH_GENERATION_BACKEND,
 )
+
+
+def test_saib_llm_runs_local_pytorch_with_no_args(monkeypatch):
+    # Bare `saib-llm` should run a self-contained local PyTorch LM benchmark
+    # (no server, no required --model), mirroring how `saib-pt` runs defaults.
+    import pytest
+
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.config_pt_tf import get_device_name_pytorch
+
+    monkeypatch.setattr("sys.argv", ["saib-llm"])
+
+    args = parse_arguments()
+    config = build_generation_config_from_args(args)
+
+    assert args.backend == PYTORCH_GENERATION_BACKEND
+    assert args.model == "SimpleTransformerLM"
+    # No --device given -> auto-detected best device, same logic as the CV benchmarks.
+    assert config.device_name == get_device_name_pytorch()
+    assert config.base_url == ""
 
 
 def _args(**overrides) -> argparse.Namespace:

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -25,8 +25,15 @@ from simple_ai_benchmarking.database import (
     build_publish_parser,
     enrich_benchmark_data,
     get_git_commit_hash_from_package_version,
+    read_csv_and_create_benchmark_dataset,
 )
 from simple_ai_benchmarking.llm_database import read_csv_and_create_llm_benchmark_dataset
+
+
+def _write_csv(content: str) -> str:
+    with NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as csv_file:
+        csv_file.write(content)
+        return csv_file.name
 
 
 class TestPublishDatabase(unittest.TestCase):
@@ -68,6 +75,30 @@ class TestPublishDatabase(unittest.TestCase):
         self.assertEqual(benchmark_data[0].backend, "llama.cpp")
         self.assertEqual(benchmark_data[0].generated_tokens_per_second, 42.5)
         self.assertEqual(benchmark_data[0].benchmark_spec_name, "saib_llm_generation")
+
+    def test_cv_reader_rejects_llm_csv_with_clear_error(self):
+        # An LLM CSV (has bench_info_backend, no bench_info_workload_type).
+        csv_path = _write_csv(
+            "bench_info_backend,bench_info_model\nollama,llama3\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                read_csv_and_create_benchmark_dataset(csv_path)
+        finally:
+            os.remove(csv_path)
+        self.assertIn("saib-pub-llm", str(ctx.exception))
+
+    def test_llm_reader_rejects_cv_csv_with_clear_error(self):
+        # A CV CSV (has bench_info_workload_type, no bench_info_backend).
+        csv_path = _write_csv(
+            "bench_info_workload_type,bench_info_model\nInferenceWorkload,ResNet50\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                read_csv_and_create_llm_benchmark_dataset(csv_path)
+        finally:
+            os.remove(csv_path)
+        self.assertIn("saib-pub", str(ctx.exception))
 
     def test_build_publish_parser_parses_common_args(self):
         parser = build_publish_parser("desc")


### PR DESCRIPTION
**Why:** `saib-llm` required `--model` and defaulted to the `openai-compatible` backend, so it couldn't run bare like `saib-pt`. Separately, running `saib-pub` on an LLM CSV (or vice-versa) crashed with a cryptic `KeyError`.

**What:**
- `saib-llm` runs a self-contained local PyTorch LM benchmark with **no arguments**: default backend `pytorch-simple-transformer`, `--model` defaults to `SimpleTransformerLM`, and `--device` auto-detects the best device (cuda/mps/cpu) via the same `get_device_name_pytorch()` the CV benchmarks use. Repetitions stay at 3.
- Publish commands now fail with a clear, actionable message on the wrong CSV family: `saib-pub` on an LLM CSV says to use `saib-pub-llm`, and `saib-pub-llm` on a CV CSV says to use `saib-pub`.
- README updated (bare `saib-llm` shown first; `pytorch-simple-transformer` no longer mislabeled as non-default).
- Version bump 0.7.0 → 0.7.1.

Note: CV's `BATCH_SIZE=32`/`NUM_BATCHES=150` were intentionally **not** mapped to LLM `concurrency`/`requests` — token generation is far costlier per unit, so LLM-appropriate defaults (requests=10, concurrency=1, 256 generated tokens) are kept.

**Test:** `uv run --with torch --with pytest ... python -m pytest tests/test_llm_generation_cli.py tests/test_publish.py tests/test_llm_workload.py tests/test_benchmark_metadata.py -q` → 26 passed (added a bare-`saib-llm` default-device test and wrong-CSV-family error tests). Also smoke-ran bare `saib-llm` end-to-end producing a summary + CSV. `compileall` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)