### PR TITLE
feat: add KV-cache 1B and HuggingFace LLM workloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,10 @@ setuptools.setup(
             "torch>=1.0.0",
             "torchvision",
             "torchaudio",
+            "transformers",
         ],
+        # Optional: real FP8 / int8 / int4 low-precision kernels (recent GPU).
+        "lowbit": ["torchao"],
         "tfdml": ["tensorflow-cpu==2.10.0", "tensorflow-directml-plugin"],
         "tf": ["tensorflow>=2.3.0"],
         "xlsx": ["openpyxl"],

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -13,7 +13,10 @@ SPEC_VERSION = "1.0"
 # v1 aggregate-only latency. v2 results carry their own profile/runner hashes and
 # never mix with v1 rows. Bumped to 2.1 when local-backend concurrency became a
 # batched forward pass (concurrency = batch size) instead of competing threads,
-# changing throughput methodology for the pytorch backend.
+# changing throughput methodology for the pytorch backend. Newer backends (the
+# KV-cache decoder and the Hugging Face causal-LM backend) keep this spec: they
+# follow the same measurement contract and are distinguished by their own
+# backend_protocol_class in the profile, so existing backends stay comparable.
 LLM_SPEC_VERSION = "2.1"
 
 CV_RUNNER_ID = "saib.cv.classification.v1"

--- a/simple_ai_benchmarking/config_structures.py
+++ b/simple_ai_benchmarking/config_structures.py
@@ -119,6 +119,7 @@ class GenerationModelConfig:
     embedding_dim: int = 256
     attention_heads: int = 4
     transformer_layers: int = 4
+    feedforward_dim: int = 1024
 
 
 @dataclass
@@ -138,7 +139,7 @@ class LLMGenerationConfig:
     requests: int = 10
     warmup_requests: int = 1
     concurrency: int = 1
-    prompt_tokens: int = 128
+    prompt_tokens: int = 2048
     generated_tokens: int = 256
     context_length: int = 4096
     precision: NumericalPrecision = NumericalPrecision.DEFAULT_PRECISION

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -29,16 +29,53 @@ from simple_ai_benchmarking.config_structures import (
 from simple_ai_benchmarking.llm_results import LLMBenchmarkLogger
 from simple_ai_benchmarking.workloads.factory import WorkloadFactory
 from simple_ai_benchmarking.workloads.llm_workload import (
+    HF_CAUSAL_BACKEND,
     OLLAMA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
     PYTORCH_GENERATION_BACKEND,
+    PYTORCH_KV_DECODER_BACKEND,
 )
 
 SUPPORTED_LLM_BACKENDS = (
     OPENAI_COMPATIBLE_BACKEND,
     OLLAMA_BACKEND,
     PYTORCH_GENERATION_BACKEND,
+    PYTORCH_KV_DECODER_BACKEND,
+    HF_CAUSAL_BACKEND,
 )
+
+# Local PyTorch backends that build and run a model in-process (vs HTTP serving
+# backends). They share device auto-detection and framework metadata defaults.
+LOCAL_PYTORCH_BACKENDS = (
+    PYTORCH_GENERATION_BACKEND,
+    PYTORCH_KV_DECODER_BACKEND,
+    HF_CAUSAL_BACKEND,
+)
+
+# Backends `saib-llm` runs when no --backend is given: the lightweight reference
+# transformer, the heavier custom KV-cache decoder, and a real Hugging Face model.
+# This mirrors how the CV benchmark runs several models in a single invocation.
+DEFAULT_LLM_BACKENDS = (
+    PYTORCH_GENERATION_BACKEND,
+    PYTORCH_KV_DECODER_BACKEND,
+    HF_CAUSAL_BACKEND,
+)
+
+# Fixed ~1B-parameter geometry for the custom KV-cache decoder. Intentionally not
+# exposed as user-tunable presets: the custom LM simply defaults to ~1B. Mirrors
+# the defaults baked into KVCacheDecoderLM.
+KV_DECODER_DEFAULT_GEOMETRY = dict(
+    embedding_dim=2048,
+    transformer_layers=16,
+    attention_heads=16,
+    feedforward_dim=5632,
+)
+
+# Default Hugging Face causal LM for the huggingface-causal backend. Only the
+# model config is fetched and the weights are randomly initialised (approach B),
+# so no large checkpoint is downloaded. Qwen3 is open (Apache-2.0, ungated) and
+# recent. Override with --model <hf_repo_id>.
+DEFAULT_HF_MODEL = "Qwen/Qwen3-1.7B"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -46,7 +83,9 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         choices=SUPPORTED_LLM_BACKENDS,
-        default=PYTORCH_GENERATION_BACKEND,
+        default=None,
+        help="Generation backend to run. Default: None, which runs all local "
+        "workloads (simple transformer, KV-cache decoder, Hugging Face model).",
     )
     parser.add_argument("--base-url", default=None)
     parser.add_argument("--model", default="SimpleTransformerLM")
@@ -54,7 +93,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--warmup-requests", type=int, default=1)
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--concurrency", type=int, default=1)
-    parser.add_argument("--prompt-tokens", type=int, default=128)
+    parser.add_argument("--prompt-tokens", type=int, default=2048)
     parser.add_argument("--generated-tokens", type=int, default=256)
     parser.add_argument("--context-length", type=int, default=4096)
     parser.add_argument("--timeout-s", type=float, default=120.0)
@@ -72,6 +111,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--embedding-dim", type=int, default=256)
     parser.add_argument("--transformer-layers", type=int, default=4)
     parser.add_argument("--attention-heads", type=int, default=4)
+    parser.add_argument("--feedforward-dim", type=int, default=1024)
     parser.add_argument("--out-file-base", default="llm_results")
     return parser.parse_args()
 
@@ -79,23 +119,47 @@ def parse_arguments() -> argparse.Namespace:
 def _default_base_url(backend: str) -> str:
     if backend == OLLAMA_BACKEND:
         return os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
-    if backend == PYTORCH_GENERATION_BACKEND:
+    if backend in LOCAL_PYTORCH_BACKENDS:
         return ""
     return os.environ.get("OPENAI_BASE_URL", "https://api.openai.com")
 
 
 def build_generation_config_from_args(
     args: argparse.Namespace,
+    backend: str = None,
 ) -> LLMGenerationConfig:
+    # `backend` lets the caller build a config for a specific backend (used when
+    # one invocation runs several backends); falls back to the parsed --backend.
+    backend = backend or args.backend
+
     api_key = args.api_key
     if api_key is None and args.api_key_env:
         api_key = os.environ.get(args.api_key_env)
+
+    # The custom KV-cache decoder always uses its fixed ~1B geometry; other local
+    # backends take the individual geometry flags (the HF backend ignores these
+    # and builds from the model's own config).
+    if backend == PYTORCH_KV_DECODER_BACKEND:
+        geometry = dict(KV_DECODER_DEFAULT_GEOMETRY)
+    else:
+        geometry = dict(
+            embedding_dim=args.embedding_dim,
+            transformer_layers=args.transformer_layers,
+            attention_heads=args.attention_heads,
+            feedforward_dim=args.feedforward_dim,
+        )
+
+    # The HF backend takes a Hugging Face repo id via --model; substitute the
+    # default when the user left --model at its (non-HF) placeholder value.
+    model = args.model
+    if backend == HF_CAUSAL_BACKEND and model in ("", "SimpleTransformerLM"):
+        model = DEFAULT_HF_MODEL
 
     # Default to the best local device (cuda/mps/cpu), matching how the CV
     # benchmarks pick their device, unless one was explicitly requested.
     device_name = args.device
     if device_name is None:
-        if args.backend == PYTORCH_GENERATION_BACKEND:
+        if backend in LOCAL_PYTORCH_BACKENDS:
             from simple_ai_benchmarking.config_pt_tf import get_device_name_pytorch
 
             device_name = get_device_name_pytorch()
@@ -106,12 +170,19 @@ def build_generation_config_from_args(
     ai_framework_extra_info = args.ai_framework_extra_info
     accelerator = args.accelerator
     weight_source = args.weight_source
-    if args.backend == PYTORCH_GENERATION_BACKEND:
+    if backend in LOCAL_PYTORCH_BACKENDS:
         import torch
 
         ai_framework_version = ai_framework_version or torch.__version__
         ai_framework_extra_info = ai_framework_extra_info or device_name
-        compute_precision = args.compute_precision or "FP32"
+        # The heavier backends default to bf16; the lightweight reference
+        # transformer keeps fp32 so its established results stay comparable.
+        default_precision = (
+            "BF16"
+            if backend in (PYTORCH_KV_DECODER_BACKEND, HF_CAUSAL_BACKEND)
+            else "FP32"
+        )
+        compute_precision = args.compute_precision or default_precision
         quantization = args.quantization or "none"
         weight_source = weight_source or "random_weights"
         if accelerator == "unknown":
@@ -126,9 +197,9 @@ def build_generation_config_from_args(
         quantization = args.quantization
 
     return LLMGenerationConfig(
-        backend=args.backend,
+        backend=backend,
         device_name=device_name,
-        model=args.model,
+        model=model,
         requests=args.requests,
         warmup_requests=args.warmup_requests,
         concurrency=args.concurrency,
@@ -142,25 +213,40 @@ def build_generation_config_from_args(
         ai_framework_version=ai_framework_version,
         ai_framework_extra_info=ai_framework_extra_info,
         model_params=args.model_params,
-        base_url=args.base_url or _default_base_url(args.backend),
+        base_url=args.base_url or _default_base_url(backend),
         api_key=api_key,
         timeout_s=args.timeout_s,
         model_cfg=GenerationModelConfig(
             vocab_size=args.vocab_size,
             context_length=args.context_length,
-            embedding_dim=args.embedding_dim,
-            attention_heads=args.attention_heads,
-            transformer_layers=args.transformer_layers,
+            embedding_dim=geometry["embedding_dim"],
+            attention_heads=geometry["attention_heads"],
+            transformer_layers=geometry["transformer_layers"],
+            feedforward_dim=geometry["feedforward_dim"],
         ),
     )
 
 
+def build_generation_configs(args: argparse.Namespace):
+    """One config per backend to run: the explicit --backend, or all the default
+    local backends (mirrors the CV benchmark running several models at once)."""
+    if args.backend is not None:
+        return [build_generation_config_from_args(args, args.backend)]
+    return [
+        build_generation_config_from_args(args, backend)
+        for backend in DEFAULT_LLM_BACKENDS
+    ]
+
+
 def run_llm_generation_cli() -> None:
     args = parse_arguments()
-    config = build_generation_config_from_args(args)
-    workload = WorkloadFactory.create_workload(config, AIFramework.PYTORCH)
+    configs = build_generation_configs(args)
+    workloads = [
+        WorkloadFactory.create_workload(config, AIFramework.PYTORCH)
+        for config in configs
+    ]
     process_workloads(
-        [workload],
+        workloads,
         out_file_base=args.out_file_base,
         repetitions=args.repetitions,
         result_logger=LLMBenchmarkLogger(),

--- a/simple_ai_benchmarking/models/generation_factory.py
+++ b/simple_ai_benchmarking/models/generation_factory.py
@@ -38,4 +38,18 @@ class GenerationModelFactory:
             embedding_dim=model_cfg.embedding_dim,
             num_heads=model_cfg.attention_heads,
             num_layers=model_cfg.transformer_layers,
+            feedforward_dim=model_cfg.feedforward_dim,
+        )
+
+    @staticmethod
+    def create_pytorch_kv_decoder_model(model_cfg: GenerationModelConfig):
+        from simple_ai_benchmarking.models.pt.kv_decoder_lm import KVCacheDecoderLM
+
+        return KVCacheDecoderLM(
+            vocab_size=model_cfg.vocab_size,
+            context_length=model_cfg.context_length,
+            embedding_dim=model_cfg.embedding_dim,
+            num_heads=model_cfg.attention_heads,
+            num_layers=model_cfg.transformer_layers,
+            feedforward_dim=model_cfg.feedforward_dim,
         )

--- a/simple_ai_benchmarking/models/pt/kv_decoder_lm.py
+++ b/simple_ai_benchmarking/models/pt/kv_decoder_lm.py
@@ -1,0 +1,224 @@
+# Project Name: simple-ai-benchmarking
+# File Name: kv_decoder_lm.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# A layer's KV cache entry: (keys, values), each (batch, heads, seq, head_dim).
+LayerKV = Tuple[torch.Tensor, torch.Tensor]
+KVCache = List[LayerKV]
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Normalise in fp32 for stability, then return to the input dtype so the
+        # rest of the network runs at the requested (lower) precision.
+        dtype = x.dtype
+        x32 = x.float()
+        normed = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + self.eps)
+        return normed.to(dtype) * self.weight
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    first, second = x.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_rope(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    # x: (batch, heads, seq, head_dim); cos/sin: (seq, head_dim).
+    cos = cos[None, None, :, :]
+    sin = sin[None, None, :, :]
+    return x * cos + _rotate_half(x) * sin
+
+
+class CausalSelfAttention(nn.Module):
+    """Multi-head causal attention with RoPE and an optional KV cache.
+
+    Prefill passes the whole prompt (is_causal=True). Decode passes a single
+    token whose query attends to every cached key/value, so no causal mask is
+    needed for that step."""
+
+    def __init__(self, dim: int, num_heads: int) -> None:
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("embedding_dim must be divisible by num_heads")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.wq = nn.Linear(dim, dim, bias=False)
+        self.wk = nn.Linear(dim, dim, bias=False)
+        self.wv = nn.Linear(dim, dim, bias=False)
+        self.wo = nn.Linear(dim, dim, bias=False)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        past_kv: Optional[LayerKV] = None,
+    ) -> Tuple[torch.Tensor, LayerKV]:
+        batch, seq, _ = x.shape
+        q = self.wq(x).view(batch, seq, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(batch, seq, self.num_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(batch, seq, self.num_heads, self.head_dim).transpose(1, 2)
+
+        q = _apply_rope(q, cos, sin)
+        k = _apply_rope(k, cos, sin)
+
+        if past_kv is not None:
+            past_k, past_v = past_kv
+            k = torch.cat((past_k, k), dim=2)
+            v = torch.cat((past_v, v), dim=2)
+        new_kv = (k, v)
+
+        # Causal masking only matters during prefill (multiple new queries). For a
+        # single decode token the query legitimately attends to all cached keys.
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=seq > 1)
+        out = out.transpose(1, 2).contiguous().view(batch, seq, self.num_heads * self.head_dim)
+        return self.wo(out), new_kv
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class DecoderBlock(nn.Module):
+    def __init__(self, dim: int, num_heads: int, feedforward_dim: int) -> None:
+        super().__init__()
+        self.attn_norm = RMSNorm(dim)
+        self.attn = CausalSelfAttention(dim, num_heads)
+        self.mlp_norm = RMSNorm(dim)
+        self.mlp = SwiGLU(dim, feedforward_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        past_kv: Optional[LayerKV] = None,
+    ) -> Tuple[torch.Tensor, LayerKV]:
+        attn_out, new_kv = self.attn(self.attn_norm(x), cos, sin, past_kv)
+        x = x + attn_out
+        x = x + self.mlp(self.mlp_norm(x))
+        return x, new_kv
+
+
+class KVCacheDecoderLM(nn.Module):
+    """Decoder-only transformer with RoPE, RMSNorm, SwiGLU and a real KV cache.
+
+    Unlike SimpleTransformerLanguageModel (which recomputes the full sequence on
+    every step), this keeps per-layer key/value caches so decode is O(1) per
+    token. That makes time-to-first-token (prefill) and decode throughput
+    measure what they do on a production serving stack."""
+
+    def __init__(
+        self,
+        vocab_size: int = 32000,
+        context_length: int = 4096,
+        embedding_dim: int = 2048,
+        num_heads: int = 16,
+        num_layers: int = 16,
+        feedforward_dim: int = 5632,
+        rope_base: float = 10000.0,
+    ) -> None:
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.context_length = context_length
+        self.head_dim = embedding_dim // num_heads
+        self.token_embedding = nn.Embedding(vocab_size, embedding_dim)
+        self.layers = nn.ModuleList(
+            DecoderBlock(embedding_dim, num_heads, feedforward_dim)
+            for _ in range(num_layers)
+        )
+        self.norm = RMSNorm(embedding_dim)
+        self.lm_head = nn.Linear(embedding_dim, vocab_size, bias=False)
+
+        inv_freq = 1.0 / (
+            rope_base
+            ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def _rope(
+        self, start: int, length: int, device: torch.device, dtype: torch.dtype
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        positions = torch.arange(start, start + length, device=device, dtype=torch.float32)
+        freqs = torch.outer(positions, self.inv_freq.to(device))
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return emb.cos().to(dtype), emb.sin().to(dtype)
+
+    def forward(
+        self, token_ids: torch.Tensor, past_kvs: Optional[KVCache] = None
+    ) -> Tuple[torch.Tensor, KVCache]:
+        _, seq = token_ids.shape
+        past_len = 0 if past_kvs is None else past_kvs[0][0].shape[2]
+        hidden = self.token_embedding(token_ids)
+        cos, sin = self._rope(past_len, seq, hidden.device, hidden.dtype)
+
+        new_cache: KVCache = []
+        for index, layer in enumerate(self.layers):
+            layer_past = None if past_kvs is None else past_kvs[index]
+            hidden, layer_kv = layer(hidden, cos, sin, layer_past)
+            new_cache.append(layer_kv)
+
+        logits = self.lm_head(self.norm(hidden))
+        return logits, new_cache
+
+    @torch.no_grad()
+    def prefill(self, token_ids: torch.Tensor) -> Tuple[torch.Tensor, KVCache]:
+        """Process the prompt once and return (next_token, kv_cache)."""
+        logits, cache = self.forward(token_ids[:, -self.context_length :])
+        next_token = logits[:, -1:, :].argmax(dim=-1)
+        return next_token, cache
+
+    @torch.no_grad()
+    def decode_step(
+        self, token: torch.Tensor, past_kvs: KVCache
+    ) -> Tuple[torch.Tensor, KVCache]:
+        """Advance one token using the cache (no full-sequence recompute)."""
+        logits, cache = self.forward(token, past_kvs)
+        next_token = logits[:, -1:, :].argmax(dim=-1)
+        return next_token, cache
+
+    @torch.no_grad()
+    def generate(self, token_ids: torch.Tensor, generated_tokens: int) -> torch.Tensor:
+        """Greedy generation using the KV cache (returns the full sequence)."""
+        self.eval()
+        next_token, cache = self.prefill(token_ids)
+        out = torch.cat((token_ids, next_token), dim=1)
+        for _ in range(max(0, generated_tokens - 1)):
+            next_token, cache = self.decode_step(next_token, cache)
+            out = torch.cat((out, next_token), dim=1)
+        return out

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.7.1"
+VERSION = "0.8.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/factory.py
+++ b/simple_ai_benchmarking/workloads/factory.py
@@ -47,11 +47,15 @@ class WorkloadFactory:
         workload_cfg: LLMGenerationConfig, framework: AIFramework
     ) -> AIWorkload:
         from simple_ai_benchmarking.workloads.llm_workload import (
+            HF_CAUSAL_BACKEND,
             OLLAMA_BACKEND,
             OPENAI_COMPATIBLE_BACKEND,
             PYTORCH_GENERATION_BACKEND,
+            PYTORCH_KV_DECODER_BACKEND,
+            HuggingFaceCausalGeneration,
             OllamaGeneration,
             OpenAICompatibleGeneration,
+            PyTorchKVDecoderGeneration,
             PyTorchLocalGeneration,
         )
 
@@ -60,9 +64,14 @@ class WorkloadFactory:
             return OpenAICompatibleGeneration(workload_cfg)
         if backend == OLLAMA_BACKEND:
             return OllamaGeneration(workload_cfg)
-        if backend == PYTORCH_GENERATION_BACKEND:
+        local_backends = {
+            PYTORCH_GENERATION_BACKEND: PyTorchLocalGeneration,
+            PYTORCH_KV_DECODER_BACKEND: PyTorchKVDecoderGeneration,
+            HF_CAUSAL_BACKEND: HuggingFaceCausalGeneration,
+        }
+        if backend in local_backends:
             if framework is AIFramework.PYTORCH:
-                return PyTorchLocalGeneration(workload_cfg)
+                return local_backends[backend](workload_cfg)
             raise ValueError(
                 f"Local generation backend requires PyTorch, got {framework}"
             )

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -37,8 +37,20 @@ from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
 
 
 PYTORCH_GENERATION_BACKEND = "pytorch-simple-transformer"
+PYTORCH_KV_DECODER_BACKEND = "pytorch-kv-decoder"
+HF_CAUSAL_BACKEND = "huggingface-causal"
 OPENAI_COMPATIBLE_BACKEND = "openai-compatible"
 OLLAMA_BACKEND = "ollama"
+
+# Floating-point precisions applied by a plain dtype cast of the random-weight
+# model (no extra dependency). FP8 and int8/int4 are not dtype casts: they need
+# real low-precision kernels (torchao) and a recent GPU, handled separately.
+PRECISION_TO_DTYPE = {
+    "": "float32",
+    "FP32": "float32",
+    "FP16": "float16",
+    "BF16": "bfloat16",
+}
 
 
 @dataclass
@@ -252,6 +264,241 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
         return self.cfg.model_params or sum(
             p.numel() for p in self._model.parameters()
         )
+
+
+class _DtypeQuantGeneration(PyTorchLocalGeneration):
+    """Shared precision/quantization handling for the local model backends.
+
+    FP32/FP16/BF16 are plain dtype casts of the random-weight model (no extra
+    dependency). FP8 (compute_precision) and int8/int4 (quantization) use real
+    low-precision kernels via torchao and a recent GPU; without torchao they fail
+    with a clear message instead of silently running at a higher precision."""
+
+    _SUPPORTED_PRECISIONS = ("FP32", "FP16", "BF16", "FP8")
+    _SUPPORTED_QUANTIZATIONS = ("none", "int8", "int4")
+
+    def _precision(self) -> str:
+        return (self.cfg.compute_precision or "FP32").upper()
+
+    def _quantization(self) -> str:
+        return (self.cfg.quantization or "none").lower()
+
+    def _resolve_base_dtype(self):
+        precision = self._precision()
+        if precision == "FP8":
+            # The module is built in bf16; torchao casts the Linear layers to fp8.
+            return self._torch.bfloat16
+        dtype_name = PRECISION_TO_DTYPE.get(precision)
+        if dtype_name is None:
+            raise ValueError(
+                f"Unsupported compute precision '{self.cfg.compute_precision}' for "
+                f"{self._get_backend()}. Choose one of: "
+                f"{', '.join(self._SUPPORTED_PRECISIONS)}."
+            )
+        return getattr(self._torch, dtype_name)
+
+    def _apply_precision_quant(self, model):
+        """Apply FP8 / int8 / int4 via torchao when requested; otherwise no-op.
+
+        Call after the model is on its target device. Param counting should happen
+        before this, since quantization swaps in tensor-subclass weights."""
+        precision = self._precision()
+        quantization = self._quantization()
+        if quantization not in self._SUPPORTED_QUANTIZATIONS:
+            raise ValueError(
+                f"Unsupported quantization '{self.cfg.quantization}' for "
+                f"{self._get_backend()}. Choose one of: "
+                f"{', '.join(self._SUPPORTED_QUANTIZATIONS)}."
+            )
+        if precision != "FP8" and quantization == "none":
+            return model
+        try:
+            from torchao.quantization import quantize_
+
+            try:
+                # torchao >= 0.x Config-class API.
+                from torchao.quantization import (
+                    Float8DynamicActivationFloat8WeightConfig as fp8_config,
+                    Int4WeightOnlyConfig as int4_config,
+                    Int8WeightOnlyConfig as int8_config,
+                )
+            except ImportError:
+                # Older function-style API.
+                from torchao.quantization import (
+                    float8_dynamic_activation_float8_weight as fp8_config,
+                    int4_weight_only as int4_config,
+                    int8_weight_only as int8_config,
+                )
+        except ImportError as exc:
+            raise NotImplementedError(
+                f"compute_precision='{self.cfg.compute_precision}' / "
+                f"quantization='{self.cfg.quantization}' on {self._get_backend()} "
+                "needs torchao and a recent GPU: pip install torchao. "
+                "FP32/FP16/BF16 work without it."
+            ) from exc
+        if precision == "FP8":
+            quantize_(model, fp8_config())
+        if quantization == "int8":
+            quantize_(model, int8_config())
+        elif quantization == "int4":
+            quantize_(model, int4_config())
+        return model
+
+
+class PyTorchKVDecoderGeneration(_DtypeQuantGeneration):
+    """Heavier local generation on a decoder-only transformer with a KV cache.
+
+    Same measurement contract as PyTorchLocalGeneration, but the model keeps
+    per-layer key/value caches: time-to-first-token is the prompt prefill, and the
+    remaining tokens are produced one-at-a-time against the cache (O(1) per token)
+    rather than re-running the whole sequence. Precision (FP32/FP16/BF16) is set by
+    casting the random-weight model to the requested dtype."""
+
+    def setup(self) -> None:
+        import torch
+
+        from simple_ai_benchmarking.models.generation_factory import (
+            GenerationModelFactory,
+        )
+
+        self._torch = torch
+        self._device = torch.device(self.cfg.device_name)
+        self.cfg.model_cfg.context_length = self.cfg.context_length
+        dtype = self._resolve_base_dtype()
+        model = GenerationModelFactory.create_pytorch_kv_decoder_model(
+            self.cfg.model_cfg
+        )
+        model = model.to(device=self._device, dtype=dtype)
+        if self.cfg.model_params == 0:
+            self.cfg.model_params = sum(p.numel() for p in model.parameters())
+        model = self._apply_precision_quant(model)
+        self._model = model.eval()
+
+    def _generate_batch(self, batch_size: int) -> List[GenerationRequestResult]:
+        prompt_tokens = self.cfg.prompt_tokens
+        input_ids = (
+            self._torch.arange(
+                prompt_tokens, device=self._device, dtype=self._torch.long
+            )
+            .unsqueeze(0)
+            .expand(batch_size, prompt_tokens)
+            .contiguous()
+        )
+        input_ids = input_ids % self.cfg.model_cfg.vocab_size
+
+        generated_tokens = max(1, self.cfg.generated_tokens)
+
+        # Prefill (= time-to-first-token), then cached single-token decode steps.
+        start = time.perf_counter()
+        next_token, cache = self._model.prefill(input_ids)
+        self._sync_device()
+        time_to_first_token_s = time.perf_counter() - start
+
+        for _ in range(generated_tokens - 1):
+            next_token, cache = self._model.decode_step(next_token, cache)
+        self._sync_device()
+
+        return [
+            GenerationRequestResult(
+                prompt_tokens=prompt_tokens,
+                generated_tokens=generated_tokens,
+                time_to_first_token_s=time_to_first_token_s,
+            )
+            for _ in range(batch_size)
+        ]
+
+    def _get_backend(self) -> str:
+        return PYTORCH_KV_DECODER_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return PYTORCH_KV_DECODER_BACKEND
+
+
+class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
+    """Local generation on a real Hugging Face causal LM architecture.
+
+    Builds the model from the repo's config and randomly initialises the weights
+    (no checkpoint download), so it exercises a production architecture (e.g.
+    Llama) at its true size. `cfg.model` is the Hugging Face repo id. Uses the
+    model's built-in KV cache: prefill = time-to-first-token, then cached decode.
+    Requires the optional `transformers` dependency; if it is missing the workload
+    simply fails (and the surrounding run continues with the other workloads)."""
+
+    def setup(self) -> None:
+        import torch
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        self._torch = torch
+        self._device = torch.device(self.cfg.device_name)
+        dtype = self._resolve_base_dtype()
+
+        config = AutoConfig.from_pretrained(self.cfg.model)
+        self._vocab_size = config.vocab_size
+        try:
+            model = AutoModelForCausalLM.from_config(config, torch_dtype=dtype)
+        except TypeError:
+            # Older transformers without the torch_dtype kwarg on from_config.
+            model = AutoModelForCausalLM.from_config(config).to(dtype=dtype)
+        model = model.to(self._device)
+        if self.cfg.model_params == 0:
+            self.cfg.model_params = sum(p.numel() for p in model.parameters())
+        model = self._apply_precision_quant(model)
+        self._model = model.eval()
+
+    def _generate_batch(self, batch_size: int) -> List[GenerationRequestResult]:
+        torch = self._torch
+        prompt_tokens = self.cfg.prompt_tokens
+        input_ids = (
+            torch.arange(prompt_tokens, device=self._device, dtype=torch.long)
+            .unsqueeze(0)
+            .expand(batch_size, prompt_tokens)
+            .contiguous()
+        )
+        input_ids = input_ids % self._vocab_size
+
+        generated_tokens = max(1, self.cfg.generated_tokens)
+
+        with torch.no_grad():
+            # Prefill (= time-to-first-token), then cached single-token decode.
+            start = time.perf_counter()
+            outputs = self._model(input_ids=input_ids, use_cache=True)
+            past = outputs.past_key_values
+            next_token = outputs.logits[:, -1:, :].argmax(dim=-1)
+            self._sync_device()
+            time_to_first_token_s = time.perf_counter() - start
+
+            for _ in range(generated_tokens - 1):
+                outputs = self._model(
+                    input_ids=next_token, past_key_values=past, use_cache=True
+                )
+                past = outputs.past_key_values
+                next_token = outputs.logits[:, -1:, :].argmax(dim=-1)
+            self._sync_device()
+
+        return [
+            GenerationRequestResult(
+                prompt_tokens=prompt_tokens,
+                generated_tokens=generated_tokens,
+                time_to_first_token_s=time_to_first_token_s,
+            )
+            for _ in range(batch_size)
+        ]
+
+    def _get_backend(self) -> str:
+        return HF_CAUSAL_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return HF_CAUSAL_BACKEND
+
+    def _get_ai_framework_version(self) -> str:
+        if self.cfg.ai_framework_version:
+            return self.cfg.ai_framework_version
+        try:
+            import transformers
+
+            return transformers.__version__
+        except Exception:
+            return self._torch.__version__
 
 
 class HTTPGenerationWorkload(LLMGenerationWorkload):

--- a/tests/test_kv_decoder.py
+++ b/tests/test_kv_decoder.py
@@ -1,0 +1,220 @@
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from simple_ai_benchmarking.config_structures import (
+    GenerationModelConfig,
+    LLMGenerationConfig,
+)
+from simple_ai_benchmarking.models.pt.kv_decoder_lm import KVCacheDecoderLM
+from simple_ai_benchmarking.workloads.llm_workload import (
+    HF_CAUSAL_BACKEND,
+    PYTORCH_KV_DECODER_BACKEND,
+    HuggingFaceCausalGeneration,
+    PyTorchKVDecoderGeneration,
+)
+
+
+def _skip_if_torchao_available():
+    # FP8/int8/int4 only raise NotImplementedError when torchao is absent; when it
+    # is installed those paths run real kernels (GPU), so skip the negative tests.
+    try:
+        import torchao  # noqa: F401
+
+        pytest.skip("torchao installed; low-precision paths run on GPU")
+    except ImportError:
+        pass
+
+
+def _tiny_model() -> KVCacheDecoderLM:
+    torch.manual_seed(0)
+    return KVCacheDecoderLM(
+        vocab_size=64,
+        context_length=64,
+        embedding_dim=32,
+        num_heads=4,
+        num_layers=2,
+        feedforward_dim=64,
+    ).eval()
+
+
+def _reference_generate(model: KVCacheDecoderLM, prompt, generated_tokens):
+    # No cache: recompute the full growing sequence each step (slow but obviously
+    # correct), used as ground truth for the cached path.
+    seq = prompt.clone()
+    for _ in range(generated_tokens):
+        logits, _ = model.forward(seq)
+        next_token = logits[:, -1:, :].argmax(dim=-1)
+        seq = torch.cat([seq, next_token], dim=1)
+    return seq
+
+
+def test_kv_cache_matches_full_recompute():
+    model = _tiny_model()
+    prompt = torch.randint(0, 64, (1, 8))
+    cached = model.generate(prompt, 6)
+    assert torch.equal(cached, _reference_generate(model, prompt, 6))
+
+
+def test_batched_kv_cache_matches_full_recompute():
+    model = _tiny_model()
+    prompt = torch.randint(0, 64, (3, 8))
+    cached = model.generate(prompt, 4)
+    assert torch.equal(cached, _reference_generate(model, prompt, 4))
+
+
+def _tiny_kv_config(**overrides) -> LLMGenerationConfig:
+    defaults = dict(
+        backend=PYTORCH_KV_DECODER_BACKEND,
+        device_name="cpu",
+        requests=2,
+        warmup_requests=0,
+        concurrency=1,
+        prompt_tokens=4,
+        generated_tokens=3,
+        context_length=16,
+        compute_precision="FP32",
+        model_cfg=GenerationModelConfig(
+            vocab_size=64,
+            context_length=16,
+            embedding_dim=32,
+            attention_heads=4,
+            transformer_layers=2,
+            feedforward_dim=64,
+        ),
+    )
+    defaults.update(overrides)
+    return LLMGenerationConfig(**defaults)
+
+
+def test_kv_decoder_workload_runs_and_measures_ttft():
+    workload = PyTorchKVDecoderGeneration(_tiny_kv_config())
+    workload.setup()
+    results, duration = workload._run_measured()
+
+    assert len(results) == 2
+    assert duration >= 0
+    assert all(r.time_to_first_token_s >= 0 for r in results)
+    assert all(r.generated_tokens == 3 for r in results)
+
+
+def test_kv_decoder_workload_respects_bf16_precision():
+    workload = PyTorchKVDecoderGeneration(_tiny_kv_config(compute_precision="BF16"))
+    workload.setup()
+    assert next(workload._model.parameters()).dtype == torch.bfloat16
+
+
+def test_kv_decoder_integer_quantization_requires_torchao():
+    _skip_if_torchao_available()
+    workload = PyTorchKVDecoderGeneration(_tiny_kv_config(quantization="int8"))
+    with pytest.raises(NotImplementedError):
+        workload.setup()
+
+
+def test_kv_decoder_fp8_requires_torchao():
+    _skip_if_torchao_available()
+    workload = PyTorchKVDecoderGeneration(_tiny_kv_config(compute_precision="FP8"))
+    with pytest.raises(NotImplementedError):
+        workload.setup()
+
+
+def test_kv_decoder_rejects_unknown_precision():
+    workload = PyTorchKVDecoderGeneration(_tiny_kv_config(compute_precision="FP9"))
+    with pytest.raises(ValueError):
+        workload.setup()
+
+
+def test_kv_decoder_default_is_about_1b_params():
+    # Build on the meta device so no real memory is allocated for the param count.
+    with torch.device("meta"):
+        model = KVCacheDecoderLM()
+    num_params = sum(p.numel() for p in model.parameters())
+    assert 0.8e9 < num_params < 1.2e9
+
+
+def test_kv_decoder_cli_defaults_to_1b_bf16(monkeypatch):
+    from simple_ai_benchmarking.llm_generation import (
+        build_generation_config_from_args,
+        parse_arguments,
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["saib-llm", "--backend", PYTORCH_KV_DECODER_BACKEND, "--device", "cpu"],
+    )
+    config = build_generation_config_from_args(parse_arguments())
+
+    # Fixed ~1B geometry (no presets) and bf16 by default.
+    assert config.model_cfg.embedding_dim == 2048
+    assert config.model_cfg.transformer_layers == 16
+    assert config.model_cfg.attention_heads == 16
+    assert config.model_cfg.feedforward_dim == 5632
+    assert config.compute_precision == "BF16"
+    # Prefill default was raised so time-to-first-token is measurable.
+    assert config.prompt_tokens == 2048
+
+
+def test_hf_workload_runs_on_random_init_model(monkeypatch):
+    transformers = pytest.importorskip("transformers")
+    from transformers import LlamaConfig
+
+    tiny = LlamaConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+    )
+    # Approach B without network: AutoConfig.from_pretrained returns a real config
+    # object, then the model is built (random weights) from it.
+    monkeypatch.setattr(
+        transformers.AutoConfig, "from_pretrained", lambda *a, **k: tiny
+    )
+
+    config = LLMGenerationConfig(
+        backend=HF_CAUSAL_BACKEND,
+        device_name="cpu",
+        model="dummy/model",
+        requests=2,
+        warmup_requests=0,
+        concurrency=1,
+        prompt_tokens=4,
+        generated_tokens=3,
+        compute_precision="FP32",
+    )
+    workload = HuggingFaceCausalGeneration(config)
+    workload.setup()
+    results, duration = workload._run_measured()
+
+    assert len(results) == 2
+    assert duration >= 0
+    assert all(r.generated_tokens == 3 for r in results)
+    assert all(r.time_to_first_token_s >= 0 for r in results)
+
+
+def test_hf_workload_integer_quantization_requires_torchao(monkeypatch):
+    transformers = pytest.importorskip("transformers")
+    _skip_if_torchao_available()
+    from transformers import LlamaConfig
+
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        lambda *a, **k: LlamaConfig(
+            vocab_size=32, hidden_size=16, num_hidden_layers=1, num_attention_heads=2
+        ),
+    )
+    config = LLMGenerationConfig(
+        backend=HF_CAUSAL_BACKEND,
+        device_name="cpu",
+        model="dummy/model",
+        compute_precision="FP32",
+        quantization="int4",
+    )
+    with pytest.raises(NotImplementedError):
+        HuggingFaceCausalGeneration(config).setup()

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -10,24 +10,38 @@ from simple_ai_benchmarking.workloads.llm_workload import (
 )
 
 
-def test_saib_llm_runs_local_pytorch_with_no_args(monkeypatch):
-    # Bare `saib-llm` should run a self-contained local PyTorch LM benchmark
-    # (no server, no required --model), mirroring how `saib-pt` runs defaults.
+def test_saib_llm_runs_all_local_workloads_with_no_args(monkeypatch):
+    # Bare `saib-llm` should build all local LM workloads (simple transformer,
+    # KV-cache decoder, Hugging Face), mirroring how `saib-pt` runs several models.
     import pytest
 
     pytest.importorskip("torch")
     from simple_ai_benchmarking.config_pt_tf import get_device_name_pytorch
+    from simple_ai_benchmarking.llm_generation import build_generation_configs
+    from simple_ai_benchmarking.workloads.llm_workload import (
+        HF_CAUSAL_BACKEND,
+        PYTORCH_KV_DECODER_BACKEND,
+    )
 
     monkeypatch.setattr("sys.argv", ["saib-llm"])
 
     args = parse_arguments()
-    config = build_generation_config_from_args(args)
+    assert args.backend is None
+    configs = build_generation_configs(args)
 
-    assert args.backend == PYTORCH_GENERATION_BACKEND
-    assert args.model == "SimpleTransformerLM"
-    # No --device given -> auto-detected best device, same logic as the CV benchmarks.
-    assert config.device_name == get_device_name_pytorch()
-    assert config.base_url == ""
+    assert [c.backend for c in configs] == [
+        PYTORCH_GENERATION_BACKEND,
+        PYTORCH_KV_DECODER_BACKEND,
+        HF_CAUSAL_BACKEND,
+    ]
+    # Reference transformer keeps its defaults (self-contained, no server).
+    assert configs[0].model == "SimpleTransformerLM"
+    assert configs[0].device_name == get_device_name_pytorch()
+    assert configs[0].base_url == ""
+    # HF backend gets a real repo id; heavier backends default to bf16.
+    assert configs[2].model
+    assert configs[1].compute_precision == "BF16"
+    assert configs[2].compute_precision == "BF16"
 
 
 def _args(**overrides) -> argparse.Namespace:
@@ -56,6 +70,7 @@ def _args(**overrides) -> argparse.Namespace:
         embedding_dim=256,
         transformer_layers=4,
         attention_heads=4,
+        feedforward_dim=1024,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)


### PR DESCRIPTION
**Why:** The existing local LLM workload is a ~20M-param transformer with no KV cache, so time-to-first-token rounds to ~0.001s on fast GPUs and decode throughput isn't representative. We want heavier, more realistic generation benchmarks.

**What:**
- New `pytorch-kv-decoder` backend: a ~1B decoder-only model (RMSNorm/RoPE/SwiGLU/SDPA) with a real KV cache. TTFT = prompt prefill; decode is O(1) per token (cached) instead of full-sequence recompute.
- New `huggingface-causal` backend: builds a real HF causal LM architecture randomly initialised from the model config (no checkpoint download). Default `Qwen/Qwen3-1.7B` (open, ungated, recent).
- `saib-llm` now runs all local workloads by default (simple transformer + KV decoder + HF), mirroring the CV benchmark. Each runs in its own subprocess, so a failing workload (e.g. missing `transformers`, gated/OOM model) is isolated and the others still produce results.
- Default prefill raised to 2048 tokens so TTFT is measurable.
- Precision: FP32/FP16/BF16 via dtype cast (bf16 default for the heavy backends); FP8 + int8/int4 via optional `torchao` (`lowbit` extra) with a clear error when unavailable.
- `transformers` added to the `pt` extra; version bumped to 0.8.0.
- LLM spec stays at 2.1: the new backends follow the same measurement contract and are distinguished by `backend_protocol_class`, so existing backends remain comparable.

**Test:** `uv run --with pytest --with torch --with transformers python -m pytest tests/ -q` -> 39 passed; remaining 5 failures are pre-existing TensorFlow-not-installed cases unrelated to this change. torchao int8 path validated end-to-end on CPU separately. New tests in `tests/test_kv_decoder.py` cover cached-vs-recompute parity, ~1B default geometry, bf16 default, the HF workload on a tiny random-init model, and the fp8/int torchao-required error paths.