### PR TITLE
feat: add FP8/FP4 low-bit LLM workloads and -w selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I develop this application in my free time as a hobby.
 
 ## LLM Inference Benchmarking
 
-In addition to the vision/CNN workloads, SAIB can benchmark large language model (LLM) inference and report token throughput. Run it with the `saib-llm` entry point. With no arguments it runs **all three local PyTorch backends** (simple transformer, ~1B KV-cache decoder, and a Hugging Face architecture), requiring no server, just like `saib-pt` runs several models with sensible defaults:
+In addition to the vision/CNN workloads, SAIB can benchmark large language model (LLM) inference and report token throughput. Run it with the `saib-llm` entry point. With no arguments it runs **all five local PyTorch backends** (simple transformer, ~1B KV-cache decoder, a Hugging Face architecture, and that architecture in FP8 and FP4), requiring no server, just like `saib-pt` runs several models with sensible defaults:
 
 ```bash
 saib-llm
@@ -87,15 +87,15 @@ The local backends need PyTorch, and the `huggingface-causal` backend additional
 pip install simple-ai-benchmarking[pt]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git
 ```
 
-- **`transformers`** is required for the `huggingface-causal` backend. If it is missing, that workload fails with `Could not import module 'AutoModelForCausalLM'` while the other workloads still run (each workload runs in an isolated process). Quick check:
+- **`transformers`** is required for the `huggingface-causal` backends. If it is missing — or installed but incompatible with your torch — that workload fails with `Could not import module 'AutoModelForCausalLM'` while the other workloads still run (each workload runs in an isolated process). Note `transformers` 5.x imports `torch.distributed.tensor.device_mesh`, which only exists in **torch ≥2.5**, so on older torch you must use `transformers<5` (what the `pt` extra installs). Quick check:
 
   ```bash
   python -c "from transformers import AutoModelForCausalLM; import transformers; print('OK transformers', transformers.__version__)"
   ```
 
-  Install it on its own with `pip install transformers`.
+  Install it on its own with `pip install 'transformers<5'` (or upgrade to `torch>=2.5` for `transformers` 5.x).
 
-- **`torchao`** is only needed for real low-precision kernels (`--compute-precision FP8` or `--quantization int8`/`int4`) and a recent GPU. Install via the `lowbit` extra (`pip install simple-ai-benchmarking[lowbit]@git+...`) or `pip install torchao`. Without it, those options raise `NotImplementedError`; plain `FP32`/`FP16`/`BF16` casts need no extra dependency. Quick check:
+- **`torchao`** is only needed for real low-precision kernels (`--compute-precision FP8`/`FP4` or `--quantization int8`/`int4`, including the `huggingface-causal-fp8`/`-fp4` backends) and a recent GPU — FP8 needs CUDA SM 8.9+ (Ada/Hopper), FP4/NVFP4 needs Blackwell SM100. Install via the `lowbit` extra (`pip install simple-ai-benchmarking[lowbit]@git+...`) or `pip install torchao`. Without it (or on unsupported hardware), those options raise `NotImplementedError`; plain `FP32`/`FP16`/`BF16` casts need no extra dependency. Quick check:
 
   ```bash
   python -c "import torchao; print('OK torchao', torchao.__version__)"
@@ -103,7 +103,7 @@ pip install simple-ai-benchmarking[pt]@git+https://github.com/TimoIllusion/simpl
 
 ### Backends
 
-Five backends are supported — three self-contained local PyTorch backends and two HTTP backends:
+Seven backends are supported — five self-contained local PyTorch backends and two HTTP backends:
 
 - `pytorch-simple-transformer` — a small synthetic PyTorch transformer, requiring no external server or model weights (handy for quick hardware comparisons):
 
@@ -123,6 +123,18 @@ Five backends are supported — three self-contained local PyTorch backends and 
   saib-llm --backend huggingface-causal --model Qwen/Qwen3-1.7B --device cuda
   ```
 
+- `huggingface-causal-fp8` — the same Hugging Face architecture quantized to **FP8** (weights + activations) via torchao. Requires `transformers` + `torchao` and a recent GPU (CUDA SM 8.9+, i.e. Ada/Hopper or newer):
+
+  ```bash
+  saib-llm --backend huggingface-causal-fp8 --model Qwen/Qwen3-1.7B --device cuda
+  ```
+
+- `huggingface-causal-fp4` — the same architecture quantized to **FP4** (NVFP4) via torchao. Requires `transformers` + `torchao` and an **NVIDIA Blackwell (SM100) GPU**:
+
+  ```bash
+  saib-llm --backend huggingface-causal-fp4 --model Qwen/Qwen3-1.7B --device cuda
+  ```
+
 - `openai-compatible` — benchmark any server exposing the OpenAI `/v1/chat/completions` API (e.g. vLLM, llama.cpp server, LM Studio, OpenAI itself):
 
   ```bash
@@ -139,13 +151,14 @@ The benchmark performs configurable warmup and measured requests (optionally con
 
 Common options (see `saib-llm -h` for the full list):
 
+- `-w` / `--workloads` — when no `--backend` is given, 0-based indices selecting which of the default workloads to run, e.g. `-w 1` for only the second (KV-cache decoder) or `-w 1 2` for the second and third. Default: run all (mirrors `saib-pt -w`)
 - `--requests` / `--warmup-requests` — number of measured / warmup requests (default `10` / `1`)
 - `--repetitions` — number of times the measurement is repeated and averaged (default `3`); for paid HTTP endpoints, lower this to reduce cost
 - `--concurrency` — for HTTP backends (`openai-compatible`, `ollama`), the number of in-flight concurrent requests; for the local PyTorch backends, the batch size processed in a single batched forward pass (default `1`)
 - `--prompt-tokens` / `--generated-tokens` — prompt and generation lengths (default `2048` / `256`)
 - `--context-length` — model context window (default `4096`)
 - `--device` — torch device for the local backends, e.g. `cpu`, `cuda`, `mps` (default `cpu`)
-- `--compute-precision` — for `pytorch-kv-decoder` and `huggingface-causal`, applied to the model: `FP32`/`FP16`/`BF16` (plain casts) or `FP8` (needs `torchao` + recent GPU). Recorded as metadata for other backends
+- `--compute-precision` — for `pytorch-kv-decoder` and `huggingface-causal`, applied to the model: `FP32`/`FP16`/`BF16` (plain casts), `FP8` (needs `torchao` + recent GPU), or `FP4`/NVFP4 (needs `torchao` + Blackwell SM100). The `huggingface-causal-fp8`/`-fp4` backends pin FP8/FP4. Recorded as metadata for other backends
 - `--quantization` — for `pytorch-kv-decoder` and `huggingface-causal`: `none` (default), `int8`, or `int4` (the latter two need `torchao` + recent GPU). Recorded as metadata for other backends
 - `--model-params`, `--weight-source`, `--accelerator` — metadata recorded with the result
 - `--out-file-base` — output file name base (default `llm_results`)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,11 @@ setuptools.setup(
             "torch>=1.0.0",
             "torchvision",
             "torchaudio",
-            "transformers",
+            # transformers 5.x imports torch.distributed.tensor.device_mesh, which
+            # only exists in torch>=2.5; cap at <5 so the huggingface-causal backend
+            # works across the wide torch range SAIB targets. Use torch>=2.5 if you
+            # want transformers 5.x.
+            "transformers<5",
         ],
         # Optional: real FP8 / int8 / int4 low-precision kernels (recent GPU).
         "lowbit": ["torchao"],

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -30,10 +30,20 @@ from simple_ai_benchmarking.llm_results import LLMBenchmarkLogger
 from simple_ai_benchmarking.workloads.factory import WorkloadFactory
 from simple_ai_benchmarking.workloads.llm_workload import (
     HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
     OLLAMA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
     PYTORCH_GENERATION_BACKEND,
     PYTORCH_KV_DECODER_BACKEND,
+)
+
+# The Hugging Face backends (full-precision plus the FP8/FP4 low-bit variants) all
+# build a model from a Hugging Face repo id and substitute the default repo.
+HF_BACKENDS = (
+    HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
 )
 
 SUPPORTED_LLM_BACKENDS = (
@@ -42,6 +52,8 @@ SUPPORTED_LLM_BACKENDS = (
     PYTORCH_GENERATION_BACKEND,
     PYTORCH_KV_DECODER_BACKEND,
     HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
 )
 
 # Local PyTorch backends that build and run a model in-process (vs HTTP serving
@@ -50,16 +62,28 @@ LOCAL_PYTORCH_BACKENDS = (
     PYTORCH_GENERATION_BACKEND,
     PYTORCH_KV_DECODER_BACKEND,
     HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
 )
 
 # Backends `saib-llm` runs when no --backend is given: the lightweight reference
-# transformer, the heavier custom KV-cache decoder, and a real Hugging Face model.
-# This mirrors how the CV benchmark runs several models in a single invocation.
+# transformer, the heavier custom KV-cache decoder, a real Hugging Face model, and
+# its FP8/FP4 low-bit variants. Mirrors how the CV benchmark runs several models in
+# a single invocation. The low-bit variants need torchao + a recent GPU (FP4 needs
+# Blackwell); where unsupported they fail in isolation and the rest still run.
 DEFAULT_LLM_BACKENDS = (
     PYTORCH_GENERATION_BACKEND,
     PYTORCH_KV_DECODER_BACKEND,
     HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
 )
+
+# Precision pinned per low-bit HF backend (precision is part of their identity).
+HF_LOWBIT_PRECISION = {
+    HF_CAUSAL_FP8_BACKEND: "FP8",
+    HF_CAUSAL_FP4_BACKEND: "FP4",
+}
 
 # Fixed ~1B-parameter geometry for the custom KV-cache decoder. Intentionally not
 # exposed as user-tunable presets: the custom LM simply defaults to ~1B. Mirrors
@@ -70,6 +94,10 @@ KV_DECODER_DEFAULT_GEOMETRY = dict(
     attention_heads=16,
     feedforward_dim=5632,
 )
+
+# Display/identity name for the custom KV-cache decoder, so its results are not
+# mislabelled with the simple transformer's default --model placeholder.
+KV_DECODER_DEFAULT_MODEL = "KVCacheDecoderLM-1B"
 
 # Default Hugging Face causal LM for the huggingface-causal backend. Only the
 # model config is fetched and the weights are randomly initialised (approach B),
@@ -85,7 +113,19 @@ def parse_arguments() -> argparse.Namespace:
         choices=SUPPORTED_LLM_BACKENDS,
         default=None,
         help="Generation backend to run. Default: None, which runs all local "
-        "workloads (simple transformer, KV-cache decoder, Hugging Face model).",
+        "workloads (simple transformer, KV-cache decoder, Hugging Face model, "
+        "and its FP8/FP4 low-bit variants).",
+    )
+    parser.add_argument(
+        "-w",
+        "--workloads",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="INDEX",
+        help="Indices (0-based) of the default workloads to run, e.g. `-w 1` for "
+        "only the second or `-w 1 2` for the second and third. Default: None (run "
+        "all). Cannot be combined with --backend.",
     )
     parser.add_argument("--base-url", default=None)
     parser.add_argument("--model", default="SimpleTransformerLM")
@@ -149,11 +189,15 @@ def build_generation_config_from_args(
             feedforward_dim=args.feedforward_dim,
         )
 
-    # The HF backend takes a Hugging Face repo id via --model; substitute the
-    # default when the user left --model at its (non-HF) placeholder value.
+    # Give each local backend a meaningful model name when the user left --model at
+    # its placeholder: HF backends take a real repo id, and the KV-cache decoder
+    # gets its own name (otherwise it inherits the simple transformer's label).
     model = args.model
-    if backend == HF_CAUSAL_BACKEND and model in ("", "SimpleTransformerLM"):
+    placeholder = ("", "SimpleTransformerLM")
+    if backend in HF_BACKENDS and model in placeholder:
         model = DEFAULT_HF_MODEL
+    elif backend == PYTORCH_KV_DECODER_BACKEND and model in placeholder:
+        model = KV_DECODER_DEFAULT_MODEL
 
     # Default to the best local device (cuda/mps/cpu), matching how the CV
     # benchmarks pick their device, unless one was explicitly requested.
@@ -175,14 +219,19 @@ def build_generation_config_from_args(
 
         ai_framework_version = ai_framework_version or torch.__version__
         ai_framework_extra_info = ai_framework_extra_info or device_name
-        # The heavier backends default to bf16; the lightweight reference
-        # transformer keeps fp32 so its established results stay comparable.
-        default_precision = (
-            "BF16"
-            if backend in (PYTORCH_KV_DECODER_BACKEND, HF_CAUSAL_BACKEND)
-            else "FP32"
-        )
-        compute_precision = args.compute_precision or default_precision
+        # The low-bit HF backends pin their precision (it is part of their
+        # identity); the heavier backends default to bf16; the lightweight
+        # reference transformer keeps fp32 so its established results stay
+        # comparable.
+        if backend in HF_LOWBIT_PRECISION:
+            compute_precision = HF_LOWBIT_PRECISION[backend]
+        else:
+            default_precision = (
+                "BF16"
+                if backend in (PYTORCH_KV_DECODER_BACKEND, HF_CAUSAL_BACKEND)
+                else "FP32"
+            )
+            compute_precision = args.compute_precision or default_precision
         quantization = args.quantization or "none"
         weight_source = weight_source or "random_weights"
         if accelerator == "unknown":
@@ -227,20 +276,47 @@ def build_generation_config_from_args(
     )
 
 
+def select_default_backends(selection):
+    """Resolve the default backends to run from optional 0-based `-w` indices."""
+    if selection is None:
+        return list(DEFAULT_LLM_BACKENDS)
+    try:
+        return [DEFAULT_LLM_BACKENDS[i] for i in selection]
+    except IndexError:
+        raise SystemExit(
+            f"--workloads indices {list(selection)} out of range; valid indices "
+            f"are 0..{len(DEFAULT_LLM_BACKENDS) - 1}."
+        )
+
+
 def build_generation_configs(args: argparse.Namespace):
-    """One config per backend to run: the explicit --backend, or all the default
-    local backends (mirrors the CV benchmark running several models at once)."""
+    """One config per backend to run: the explicit --backend, or the default local
+    backends (optionally narrowed by `-w`), mirroring how the CV benchmark runs
+    several models at once."""
     if args.backend is not None:
+        if getattr(args, "workloads", None):
+            raise SystemExit(
+                "-w/--workloads selects among the default workloads and cannot be "
+                "combined with an explicit --backend."
+            )
         return [build_generation_config_from_args(args, args.backend)]
-    return [
-        build_generation_config_from_args(args, backend)
-        for backend in DEFAULT_LLM_BACKENDS
-    ]
+    backends = select_default_backends(getattr(args, "workloads", None))
+    return [build_generation_config_from_args(args, backend) for backend in backends]
 
 
 def run_llm_generation_cli() -> None:
+    from loguru import logger
+
     args = parse_arguments()
+    if args.backend is None:
+        logger.info("Available default workloads (use -w to select a subset):")
+        for i, backend in enumerate(DEFAULT_LLM_BACKENDS):
+            logger.info(f"  [{i}] {backend}")
     configs = build_generation_configs(args)
+    if args.backend is None:
+        logger.warning(
+            "Selected workloads: {}", [c.backend for c in configs]
+        )
     workloads = [
         WorkloadFactory.create_workload(config, AIFramework.PYTORCH)
         for config in configs

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.8.0"
+VERSION = "0.9.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/factory.py
+++ b/simple_ai_benchmarking/workloads/factory.py
@@ -48,10 +48,14 @@ class WorkloadFactory:
     ) -> AIWorkload:
         from simple_ai_benchmarking.workloads.llm_workload import (
             HF_CAUSAL_BACKEND,
+            HF_CAUSAL_FP4_BACKEND,
+            HF_CAUSAL_FP8_BACKEND,
             OLLAMA_BACKEND,
             OPENAI_COMPATIBLE_BACKEND,
             PYTORCH_GENERATION_BACKEND,
             PYTORCH_KV_DECODER_BACKEND,
+            HuggingFaceCausalFP4Generation,
+            HuggingFaceCausalFP8Generation,
             HuggingFaceCausalGeneration,
             OllamaGeneration,
             OpenAICompatibleGeneration,
@@ -68,6 +72,8 @@ class WorkloadFactory:
             PYTORCH_GENERATION_BACKEND: PyTorchLocalGeneration,
             PYTORCH_KV_DECODER_BACKEND: PyTorchKVDecoderGeneration,
             HF_CAUSAL_BACKEND: HuggingFaceCausalGeneration,
+            HF_CAUSAL_FP8_BACKEND: HuggingFaceCausalFP8Generation,
+            HF_CAUSAL_FP4_BACKEND: HuggingFaceCausalFP4Generation,
         }
         if backend in local_backends:
             if framework is AIFramework.PYTORCH:

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -39,6 +39,11 @@ from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
 PYTORCH_GENERATION_BACKEND = "pytorch-simple-transformer"
 PYTORCH_KV_DECODER_BACKEND = "pytorch-kv-decoder"
 HF_CAUSAL_BACKEND = "huggingface-causal"
+# Low-bit variants of the Hugging Face backend: the same random-init architecture
+# quantized to FP8 / FP4 (NVFP4) via torchao. They carry their own backend identity
+# (and precision_policy) so results stay comparable per precision.
+HF_CAUSAL_FP8_BACKEND = "huggingface-causal-fp8"
+HF_CAUSAL_FP4_BACKEND = "huggingface-causal-fp4"
 OPENAI_COMPATIBLE_BACKEND = "openai-compatible"
 OLLAMA_BACKEND = "ollama"
 
@@ -270,11 +275,11 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
     """Shared precision/quantization handling for the local model backends.
 
     FP32/FP16/BF16 are plain dtype casts of the random-weight model (no extra
-    dependency). FP8 (compute_precision) and int8/int4 (quantization) use real
+    dependency). FP8/FP4 (compute_precision) and int8/int4 (quantization) use real
     low-precision kernels via torchao and a recent GPU; without torchao they fail
     with a clear message instead of silently running at a higher precision."""
 
-    _SUPPORTED_PRECISIONS = ("FP32", "FP16", "BF16", "FP8")
+    _SUPPORTED_PRECISIONS = ("FP32", "FP16", "BF16", "FP8", "FP4")
     _SUPPORTED_QUANTIZATIONS = ("none", "int8", "int4")
 
     def _precision(self) -> str:
@@ -285,8 +290,9 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
 
     def _resolve_base_dtype(self):
         precision = self._precision()
-        if precision == "FP8":
-            # The module is built in bf16; torchao casts the Linear layers to fp8.
+        if precision in ("FP8", "FP4"):
+            # The module is built in bf16; torchao casts the Linear layers to the
+            # low-bit float format (fp8 / nvfp4).
             return self._torch.bfloat16
         dtype_name = PRECISION_TO_DTYPE.get(precision)
         if dtype_name is None:
@@ -310,7 +316,7 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
                 f"{self._get_backend()}. Choose one of: "
                 f"{', '.join(self._SUPPORTED_QUANTIZATIONS)}."
             )
-        if precision != "FP8" and quantization == "none":
+        if precision not in ("FP8", "FP4") and quantization == "none":
             return model
         try:
             from torchao.quantization import quantize_
@@ -338,6 +344,19 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
             ) from exc
         if precision == "FP8":
             quantize_(model, fp8_config())
+        elif precision == "FP4":
+            # NVFP4 is a torchao prototype and needs an NVIDIA Blackwell (SM100)
+            # GPU; a missing/older torchao surfaces as the same NotImplementedError.
+            try:
+                from torchao.prototype.mx_formats import NVFP4InferenceConfig
+            except ImportError as exc:
+                raise NotImplementedError(
+                    f"compute_precision='FP4' on {self._get_backend()} needs a "
+                    "torchao build with NVFP4 support and an NVIDIA Blackwell "
+                    "(SM100) GPU: pip install -U torchao. "
+                    "FP32/FP16/BF16 work without it."
+                ) from exc
+            quantize_(model, NVFP4InferenceConfig())
         if quantization == "int8":
             quantize_(model, int8_config())
         elif quantization == "int4":
@@ -426,7 +445,20 @@ class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
 
     def setup(self) -> None:
         import torch
-        from transformers import AutoConfig, AutoModelForCausalLM
+
+        # ImportError also covers transformers being present but incompatible with
+        # the installed torch (e.g. transformers 5.x needs torch>=2.5), which
+        # otherwise surfaces as a cryptic "Could not import module ...".
+        try:
+            from transformers import AutoConfig, AutoModelForCausalLM
+        except ImportError as exc:
+            raise NotImplementedError(
+                f"The {self._get_backend()} backend needs a `transformers` install "
+                "compatible with your torch version. transformers 5.x requires "
+                "torch>=2.5; SAIB pins transformers<5 for broader compatibility "
+                "(pip install 'transformers<5', or upgrade torch). "
+                f"Original import error: {exc}"
+            ) from exc
 
         self._torch = torch
         self._device = torch.device(self.cfg.device_name)
@@ -499,6 +531,33 @@ class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
             return transformers.__version__
         except Exception:
             return self._torch.__version__
+
+
+class HuggingFaceCausalFP8Generation(HuggingFaceCausalGeneration):
+    """huggingface-causal quantized to FP8 weights/activations via torchao.
+
+    Identical build/measurement path to the bf16 HF backend; the FP8 precision is
+    carried on the config (compute_precision='FP8') and applied by torchao after
+    the model is on device. Needs torchao + a recent GPU (CUDA SM 8.9+)."""
+
+    def _get_backend(self) -> str:
+        return HF_CAUSAL_FP8_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return HF_CAUSAL_FP8_BACKEND
+
+
+class HuggingFaceCausalFP4Generation(HuggingFaceCausalGeneration):
+    """huggingface-causal quantized to FP4 (NVFP4) weights/activations via torchao.
+
+    Same path as the bf16 HF backend with compute_precision='FP4'. NVFP4 is a
+    torchao prototype and needs an NVIDIA Blackwell (SM100) GPU."""
+
+    def _get_backend(self) -> str:
+        return HF_CAUSAL_FP4_BACKEND
+
+    def _get_ai_framework_name(self) -> str:
+        return HF_CAUSAL_FP4_BACKEND
 
 
 class HTTPGenerationWorkload(LLMGenerationWorkload):

--- a/tests/test_kv_decoder.py
+++ b/tests/test_kv_decoder.py
@@ -11,7 +11,11 @@ from simple_ai_benchmarking.config_structures import (
 from simple_ai_benchmarking.models.pt.kv_decoder_lm import KVCacheDecoderLM
 from simple_ai_benchmarking.workloads.llm_workload import (
     HF_CAUSAL_BACKEND,
+    HF_CAUSAL_FP4_BACKEND,
+    HF_CAUSAL_FP8_BACKEND,
     PYTORCH_KV_DECODER_BACKEND,
+    HuggingFaceCausalFP4Generation,
+    HuggingFaceCausalFP8Generation,
     HuggingFaceCausalGeneration,
     PyTorchKVDecoderGeneration,
 )
@@ -218,3 +222,85 @@ def test_hf_workload_integer_quantization_requires_torchao(monkeypatch):
     )
     with pytest.raises(NotImplementedError):
         HuggingFaceCausalGeneration(config).setup()
+
+
+def test_hf_workload_clear_error_when_transformers_unusable(monkeypatch):
+    # Simulate transformers being importable but lacking the names (the same
+    # ImportError class raised when transformers 5.x is incompatible with torch):
+    # the backend should fail with an actionable NotImplementedError, not a cryptic
+    # "Could not import module 'AutoModelForCausalLM'".
+    import types
+
+    monkeypatch.setitem(sys.modules, "transformers", types.ModuleType("transformers"))
+    config = LLMGenerationConfig(
+        backend=HF_CAUSAL_BACKEND,
+        device_name="cpu",
+        model="dummy/model",
+        compute_precision="FP32",
+    )
+    with pytest.raises(NotImplementedError, match="transformers"):
+        HuggingFaceCausalGeneration(config).setup()
+
+
+def _mock_tiny_hf_config(monkeypatch):
+    transformers = pytest.importorskip("transformers")
+    from transformers import LlamaConfig
+
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        lambda *a, **k: LlamaConfig(
+            vocab_size=32, hidden_size=16, num_hidden_layers=1, num_attention_heads=2
+        ),
+    )
+
+
+def test_hf_fp8_low_bit_backend_identity_and_requires_torchao(monkeypatch):
+    _mock_tiny_hf_config(monkeypatch)
+    config = LLMGenerationConfig(
+        backend=HF_CAUSAL_FP8_BACKEND,
+        device_name="cpu",
+        model="dummy/model",
+        compute_precision="FP8",
+    )
+    workload = HuggingFaceCausalFP8Generation(config)
+    # Distinct backend identity so FP8 results are comparable on their own.
+    assert workload._get_backend() == HF_CAUSAL_FP8_BACKEND
+    _skip_if_torchao_available()
+    with pytest.raises(NotImplementedError):
+        workload.setup()
+
+
+def test_hf_fp4_low_bit_backend_identity_and_requires_torchao(monkeypatch):
+    _mock_tiny_hf_config(monkeypatch)
+    config = LLMGenerationConfig(
+        backend=HF_CAUSAL_FP4_BACKEND,
+        device_name="cpu",
+        model="dummy/model",
+        compute_precision="FP4",
+    )
+    workload = HuggingFaceCausalFP4Generation(config)
+    assert workload._get_backend() == HF_CAUSAL_FP4_BACKEND
+    _skip_if_torchao_available()
+    with pytest.raises(NotImplementedError):
+        workload.setup()
+
+
+def test_saib_llm_low_bit_workloads_pin_precision_and_share_model(monkeypatch):
+    from simple_ai_benchmarking.llm_generation import (
+        build_generation_config_from_args,
+        parse_arguments,
+    )
+
+    for backend, expected_precision in (
+        (HF_CAUSAL_FP8_BACKEND, "FP8"),
+        (HF_CAUSAL_FP4_BACKEND, "FP4"),
+    ):
+        monkeypatch.setattr(
+            sys, "argv", ["saib-llm", "--backend", backend, "--device", "cpu"]
+        )
+        config = build_generation_config_from_args(parse_arguments())
+        # Low-bit variants reuse the HF default repo and pin their precision.
+        assert config.backend == backend
+        assert config.model  # substituted to the default HF repo id
+        assert config.compute_precision == expected_precision

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -12,14 +12,20 @@ from simple_ai_benchmarking.workloads.llm_workload import (
 
 def test_saib_llm_runs_all_local_workloads_with_no_args(monkeypatch):
     # Bare `saib-llm` should build all local LM workloads (simple transformer,
-    # KV-cache decoder, Hugging Face), mirroring how `saib-pt` runs several models.
+    # KV-cache decoder, Hugging Face, and the FP8/FP4 low-bit HF variants),
+    # mirroring how `saib-pt` runs several models.
     import pytest
 
     pytest.importorskip("torch")
     from simple_ai_benchmarking.config_pt_tf import get_device_name_pytorch
-    from simple_ai_benchmarking.llm_generation import build_generation_configs
+    from simple_ai_benchmarking.llm_generation import (
+        KV_DECODER_DEFAULT_MODEL,
+        build_generation_configs,
+    )
     from simple_ai_benchmarking.workloads.llm_workload import (
         HF_CAUSAL_BACKEND,
+        HF_CAUSAL_FP4_BACKEND,
+        HF_CAUSAL_FP8_BACKEND,
         PYTORCH_KV_DECODER_BACKEND,
     )
 
@@ -33,15 +39,81 @@ def test_saib_llm_runs_all_local_workloads_with_no_args(monkeypatch):
         PYTORCH_GENERATION_BACKEND,
         PYTORCH_KV_DECODER_BACKEND,
         HF_CAUSAL_BACKEND,
+        HF_CAUSAL_FP8_BACKEND,
+        HF_CAUSAL_FP4_BACKEND,
     ]
     # Reference transformer keeps its defaults (self-contained, no server).
     assert configs[0].model == "SimpleTransformerLM"
     assert configs[0].device_name == get_device_name_pytorch()
     assert configs[0].base_url == ""
-    # HF backend gets a real repo id; heavier backends default to bf16.
-    assert configs[2].model
+    # KV-cache decoder gets its own model label (not the simple transformer's).
+    assert configs[1].model == KV_DECODER_DEFAULT_MODEL
     assert configs[1].compute_precision == "BF16"
+    # All HF backends get a real repo id; bf16 default, low-bit variants pinned.
+    assert configs[2].model
     assert configs[2].compute_precision == "BF16"
+    assert configs[3].model == configs[2].model
+    assert configs[3].compute_precision == "FP8"
+    assert configs[4].model == configs[2].model
+    assert configs[4].compute_precision == "FP4"
+
+
+def test_saib_llm_w_flag_selects_subset_of_default_workloads(monkeypatch):
+    import pytest
+
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.llm_generation import build_generation_configs
+    from simple_ai_benchmarking.workloads.llm_workload import (
+        HF_CAUSAL_BACKEND,
+        PYTORCH_KV_DECODER_BACKEND,
+    )
+
+    # `-w 1 2` should run only the second and third default workloads.
+    monkeypatch.setattr("sys.argv", ["saib-llm", "-w", "1", "2", "--device", "cpu"])
+    configs = build_generation_configs(parse_arguments())
+
+    assert [c.backend for c in configs] == [
+        PYTORCH_KV_DECODER_BACKEND,
+        HF_CAUSAL_BACKEND,
+    ]
+
+
+def test_saib_llm_w_flag_single_workload(monkeypatch):
+    import pytest
+
+    pytest.importorskip("torch")
+    from simple_ai_benchmarking.llm_generation import build_generation_configs
+    from simple_ai_benchmarking.workloads.llm_workload import (
+        PYTORCH_KV_DECODER_BACKEND,
+    )
+
+    monkeypatch.setattr("sys.argv", ["saib-llm", "-w", "1", "--device", "cpu"])
+    configs = build_generation_configs(parse_arguments())
+
+    assert [c.backend for c in configs] == [PYTORCH_KV_DECODER_BACKEND]
+
+
+def test_saib_llm_w_flag_rejects_out_of_range(monkeypatch):
+    import pytest
+
+    from simple_ai_benchmarking.llm_generation import build_generation_configs
+
+    monkeypatch.setattr("sys.argv", ["saib-llm", "-w", "99"])
+    with pytest.raises(SystemExit):
+        build_generation_configs(parse_arguments())
+
+
+def test_saib_llm_w_flag_conflicts_with_backend(monkeypatch):
+    import pytest
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["saib-llm", "--backend", PYTORCH_GENERATION_BACKEND, "-w", "0"],
+    )
+    from simple_ai_benchmarking.llm_generation import build_generation_configs
+
+    with pytest.raises(SystemExit):
+        build_generation_configs(parse_arguments())
 
 
 def _args(**overrides) -> argparse.Namespace:


### PR DESCRIPTION
**Why:** TTFT-quality LLM benchmarking needs low-precision coverage, and bare \`saib-llm\` should let users pick a subset of the default workloads. While testing the HF backend, the real cause of the \`Could not import module 'AutoModelForCausalLM'\` error turned out to be transformers 5.x being incompatible with torch <2.5 (it imports \`torch.distributed.tensor.device_mesh\`).

**What:**
- Add \`huggingface-causal-fp8\` and \`huggingface-causal-fp4\` backends (torchao FP8 / NVFP4) with their own backend identity; pinned precision; included in the default \`saib-llm\` run (now 5 local workloads).
- Add FP4 (NVFP4) support to \`_DtypeQuantGeneration\` with a clear \`NotImplementedError\` when torchao/Blackwell is unavailable.
- Add \`-w\`/\`--workloads\` flag to select a subset of the default workloads (mirrors \`saib-pt\`); rejects combination with \`--backend\`.
- Fix the KV-decoder model label (\`KVCacheDecoderLM-1B\` instead of the simple transformer placeholder).
- Cap \`transformers<5\` in the \`pt\` extra and raise an actionable error when the import fails (missing or torch-incompatible).
- Update README (backends, install reqs, FP4/Blackwell, transformers/torch compat); bump version to 0.9.0.

**Test:** \`uv run --with torch --with transformers --with pytest python -m pytest tests/test_kv_decoder.py tests/test_llm_generation_cli.py tests/test_llm_workload.py\` (29 passed). \`python3 -m compileall simple_ai_benchmarking\` clean. The 5 pre-existing \`tensorflow\`-missing failures are unrelated.