### PR TITLE
fix: P0/P1 benchmark stability, validity, and publish robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ The local backends need PyTorch, and the `huggingface-causal` backend additional
 pip install simple-ai-benchmarking[pt]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git
 ```
 
+To also run the low-bit workloads (FP8/FP4 and int8/int4 quantization, including the `huggingface-causal-fp8`/`-fp4` backends), add the `lowbit` extra to pull in `torchao`:
+
+```bash
+pip install simple-ai-benchmarking[pt,lowbit]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git
+```
+
 - **`transformers`** is required for the `huggingface-causal` backends. If it is missing — or installed but incompatible with your torch — that workload fails with `Could not import module 'AutoModelForCausalLM'` while the other workloads still run (each workload runs in an isolated process). Note `transformers` 5.x imports `torch.distributed.tensor.device_mesh`, which only exists in **torch ≥2.5**, so on older torch you must use `transformers<5` (what the `pt` extra installs). Quick check:
 
   ```bash

--- a/simple_ai_benchmarking/benchmark.py
+++ b/simple_ai_benchmarking/benchmark.py
@@ -65,8 +65,8 @@ def process_workloads(
 def _repeat_benchmark_n_times(
     workload: AIWorkload, n_repetitions: int
 ) -> List[BenchmarkResult]:
-    set_start_method('spawn', force=True)
-    
+    set_start_method("spawn", force=True)
+
     benchmark_repetition_results = []
     for i in range(n_repetitions):
         logger.info(f"Repetition ({i+1}/{n_repetitions})")
@@ -74,8 +74,19 @@ def _repeat_benchmark_n_times(
         p = Process(target=_benchmark_process, args=(workload, result_queue))
         p.start()
         p.join()  # Wait for the process to complete
-        benchmark_result = result_queue.get()  # Retrieve the result from the process
-        
+
+        if p.exitcode != 0:
+            err_msg = f"Benchmark process crashed with exit code {p.exitcode}."
+            logger.error(err_msg)
+            benchmark_result = RuntimeError(err_msg)
+        else:
+            try:
+                benchmark_result = result_queue.get(timeout=2.0)
+            except Exception as e:
+                err_msg = f"Failed to retrieve benchmark result from queue: {e}"
+                logger.error(err_msg)
+                benchmark_result = RuntimeError(err_msg)
+
         if isinstance(benchmark_result, Exception):
             logger.error(f"Error in benchmark repetition {i+1}: {benchmark_result}")
         else:
@@ -104,8 +115,10 @@ def benchmark(workload: AIWorkload) -> BenchmarkResult:
     logger.info(f"EXECUTION: {workload.__class__.__name__}")
     workload.prepare_execution()
     check_memory("after EXECUTION PREPARATION")
+    workload.sync_device()
     with Timer() as t:
         workload.execute()
+        workload.sync_device()
     training_duration_s = t.duration_s
 
     result_log = workload.build_result_log()

--- a/simple_ai_benchmarking/benchmark.py
+++ b/simple_ai_benchmarking/benchmark.py
@@ -75,17 +75,7 @@ def _repeat_benchmark_n_times(
         p.start()
         p.join()  # Wait for the process to complete
 
-        if p.exitcode != 0:
-            err_msg = f"Benchmark process crashed with exit code {p.exitcode}."
-            logger.error(err_msg)
-            benchmark_result = RuntimeError(err_msg)
-        else:
-            try:
-                benchmark_result = result_queue.get(timeout=2.0)
-            except Exception as e:
-                err_msg = f"Failed to retrieve benchmark result from queue: {e}"
-                logger.error(err_msg)
-                benchmark_result = RuntimeError(err_msg)
+        benchmark_result = _extract_repetition_result(p.exitcode, result_queue)
 
         if isinstance(benchmark_result, Exception):
             logger.error(f"Error in benchmark repetition {i+1}: {benchmark_result}")
@@ -93,6 +83,24 @@ def _repeat_benchmark_n_times(
             benchmark_repetition_results.append(benchmark_result)
 
     return benchmark_repetition_results
+
+
+def _extract_repetition_result(exitcode, result_queue, queue_timeout: float = 2.0):
+    """Return the child's BenchmarkResult, or a RuntimeError describing the failure.
+
+    A non-zero exit code means the child crashed (e.g. CUDA OOM, segfault) without
+    putting a result, so we never block on the queue. Otherwise we read the result
+    but cap the wait so a missing result can't hang the whole run."""
+    if exitcode != 0:
+        err_msg = f"Benchmark process crashed with exit code {exitcode}."
+        logger.error(err_msg)
+        return RuntimeError(err_msg)
+    try:
+        return result_queue.get(timeout=queue_timeout)
+    except Exception as e:
+        err_msg = f"Failed to retrieve benchmark result from queue: {e}"
+        logger.error(err_msg)
+        return RuntimeError(err_msg)
 
 
 def _benchmark_process(workload: AIWorkload, result_queue: Queue) -> None:

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -8,7 +8,7 @@ LLM_BENCHMARK_FAMILY = "llm"
 
 CV_SPEC_NAME = "saib_cv_classification"
 LLM_SPEC_NAME = "saib_llm_generation"
-SPEC_VERSION = "1.0"
+SPEC_VERSION = "2.0"
 # LLM generation moved to a v2 spec when real time-to-first-token replaced the
 # v1 aggregate-only latency. v2 results carry their own profile/runner hashes and
 # never mix with v1 rows. Bumped to 2.1 when local-backend concurrency became a
@@ -19,7 +19,7 @@ SPEC_VERSION = "1.0"
 # backend_protocol_class in the profile, so existing backends stay comparable.
 LLM_SPEC_VERSION = "2.1"
 
-CV_RUNNER_ID = "saib.cv.classification.v1"
+CV_RUNNER_ID = "saib.cv.classification.v2"
 LLM_RUNNER_ID = "saib.llm.generation.v2"
 
 
@@ -60,9 +60,10 @@ def build_cv_profile(
 
 def build_cv_profile_id(profile: Mapping[str, Any]) -> str:
     shape = "x".join(str(x) for x in profile["input_shape"])
+    spec_major = str(profile["benchmark_spec_version"]).split(".", 1)[0]
     return (
         f"cv_{profile['model']}_{profile['workload_type']}_bs{profile['batch_size']}_"
-        f"{shape}_c{profile['num_classes']}_v1"
+        f"{shape}_c{profile['num_classes']}_v{spec_major}"
     ).lower().replace(" ", "_")
 
 

--- a/simple_ai_benchmarking/config_pt_tf.py
+++ b/simple_ai_benchmarking/config_pt_tf.py
@@ -88,6 +88,7 @@ def create_standard_configs_for_all_models(
                 batch_size=batch_size,
                 input_shape_without_batch=dataset_sample_shape,
                 num_batches=num_batches_inference,
+                num_classes=NUM_CLASSES,
             ),
             model_cfg=ClassificationModelConfig(
                 model_identifier=model_identifier,
@@ -104,6 +105,7 @@ def create_standard_configs_for_all_models(
                 batch_size=batch_size,
                 input_shape_without_batch=dataset_sample_shape,
                 num_batches=num_batches_training,
+                num_classes=NUM_CLASSES,
             ),
             model_cfg=ClassificationModelConfig(
                 model_identifier=model_identifier,

--- a/simple_ai_benchmarking/config_structures.py
+++ b/simple_ai_benchmarking/config_structures.py
@@ -87,6 +87,7 @@ class DatasetConfig:
     batch_size: int = 1
     input_shape_without_batch: Sequence[int] = ()
     target_shape_without_batch: Sequence[int] = ()
+    num_classes: int = 2
 
 
 @dataclass

--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -111,45 +111,66 @@ def get_package_version(package_name):
         return get_version_pkg_resources(package_name)
 
 
+# Possible outcomes of a single submission, used to drive the publish loop.
+SUBMIT_CREATED = "created"
+SUBMIT_DUPLICATE = "duplicate"
+SUBMIT_FAILED = "failed"
+
+
+def _classify_submission(data: "BenchmarkData", response) -> str:
+    """Map an HTTP response to a submission outcome.
+
+    A 409 means the server already has this exact result; that is not a hard
+    error, so the caller can skip it and keep publishing the remaining runs."""
+    if response.status_code == 201:
+        print("Successfully added:")
+        print(data.to_dict())
+        return SUBMIT_CREATED
+    if response.status_code == 409:
+        print("Skipping duplicate (identical result already on server):")
+        print(data.to_dict())
+        return SUBMIT_DUPLICATE
+    _report_submission_failure(data, response)
+    return SUBMIT_FAILED
+
+
+def _report_submission_failure(data: "BenchmarkData", response) -> None:
+    """Print a failed submission and, when the server rejected an unregistered
+    profile, point the user at the registration step they are missing."""
+    print("Failed to add:")
+    print(data.to_dict())
+    print("Response:", response.text)
+    if "Unknown benchmark profile hash" in response.text:
+        print(
+            "Hint: this benchmark profile is not registered on the server yet. "
+            "Run 'saib-register' (or 'saib-register-llm' for LLM results) against "
+            "the same database and CSV before publishing."
+        )
+
+
 def submit_benchmark_result_user_pw_auth(
     data: BenchmarkData, submit_url: str, user: str, pw: str
-) -> bool:
-    """Submit a single benchmark result to the API."""
+) -> str:
+    """Submit a single benchmark result to the API. Returns a SUBMIT_* outcome."""
 
     response = requests.post(
         submit_url, json=data.to_dict(), auth=HTTPBasicAuth(user, pw)
     )
 
-    if response.status_code == 201:
-        print("Successfully added:")
-        print(data.to_dict())
-        return True
-    else:
-        print("Failed to add:")
-        print(data.to_dict())
-        print("Response:", response.text)
-        return False
+    return _classify_submission(data, response)
 
 
 def submit_benchmark_result_token_auth(
     data: BenchmarkData, submit_url: str, api_token: str
-) -> bool:
-    """Submit a single benchmark result to the API."""
+) -> str:
+    """Submit a single benchmark result to the API. Returns a SUBMIT_* outcome."""
     headers = {
         "Authorization": f"Token {api_token}",
         "Content-Type": "application/json",
     }
     response = requests.post(submit_url, json=data.to_dict(), headers=headers)
 
-    if response.status_code == 201:
-        print("Successfully added:")
-        print(data.to_dict())
-        return True
-    else:
-        print("Failed to add:")
-        print(data.to_dict())
-        print("Response:", response.text)
-        return False
+    return _classify_submission(data, response)
 
 
 def prompt_for_updates(
@@ -396,15 +417,18 @@ def submit_results(benchmark_datasets, args, submit_url, api_token):
         print("Publishing...")
 
         if api_token:
-            success = submit_benchmark_result_token_auth(
+            outcome = submit_benchmark_result_token_auth(
                 benchmark_data, submit_url, api_token
             )
         else:
-            success = submit_benchmark_result_user_pw_auth(
+            outcome = submit_benchmark_result_user_pw_auth(
                 benchmark_data, submit_url, args.user, args.password
             )
 
-        if not success:
+        if outcome == SUBMIT_DUPLICATE:
+            # Already on the server; skip this run and keep publishing the rest.
+            continue
+        if outcome == SUBMIT_FAILED:
             print("Submission failed. Exiting...")
             break
 

--- a/simple_ai_benchmarking/dataset.py
+++ b/simple_ai_benchmarking/dataset.py
@@ -146,7 +146,7 @@ class SyntheticPytorchDataset(SyntheticDataset):
 
         self.inputs = torch.rand(self.dataset_inputs_shape, dtype=torch.float32).cpu()
         self.targets = torch.randint(
-            low=0, high=2, size=self.dataset_targets_shape, dtype=torch.int64
+            low=0, high=self.cfg.num_classes, size=self.dataset_targets_shape, dtype=torch.int64
         ).cpu()
 
 
@@ -163,7 +163,7 @@ class SyntheticTensorFlowDataset(SyntheticDataset):
 
         self.inputs = tf.random.uniform(self.dataset_inputs_shape, dtype=tf.float32)
         self.targets = tf.random.uniform(
-            self.dataset_targets_shape, minval=0, maxval=2, dtype=tf.int64
+            self.dataset_targets_shape, minval=0, maxval=self.cfg.num_classes, dtype=tf.int64
         )
 
 

--- a/simple_ai_benchmarking/entrypoints.py
+++ b/simple_ai_benchmarking/entrypoints.py
@@ -71,7 +71,7 @@ class BenchmarkDispatcher:
         print("############## SIMPLE AI BENCHMARKING ##############")
         print()
 
-    def run(self):
+    def run(self, args: List[str] = None):
         self._header()
         initialize_logger(self.LOG_FILE_PATH)
         workload_configs = build_default_pt_workload_configs(
@@ -80,34 +80,34 @@ class BenchmarkDispatcher:
             num_batches_inference=self.NUM_BATCHES_INFERENCE,
             num_batches_training=self.NUM_BATCHES_TRAINING,
         )
-        workload_configs = self._override_workload_cfg(workload_configs)
+        workload_configs = self._override_workload_cfg(workload_configs, args=args)
         workloads = WorkloadFactory.build_multiple_workloads(
             workload_configs, self.framework
         )
         process_workloads(workloads, self.results_name, repetitions=self.REPETITIONS)
 
-    def _override_workload_cfg(self, workload_cfgs: List[AIWorkloadBaseConfig]):
-        args = self.parser.parse_args()
+    def _override_workload_cfg(self, workload_cfgs: List[AIWorkloadBaseConfig], args: List[str] = None):
+        parsed_args = self.parser.parse_args(args)
         workload_info = [f"[{i}] {w}" for i, w in enumerate(workload_cfgs)]
         logger.info("Available workloads:")
         for x in workload_info:
             logger.info(x)
 
-        if args.workload_id_selection_override is not None:
+        if parsed_args.workload_id_selection_override is not None:
             workload_cfgs = [
-                workload_cfgs[i] for i in args.workload_id_selection_override
+                workload_cfgs[i] for i in parsed_args.workload_id_selection_override
             ]
             logger.warning("Selected workloads: {}", [str(x) for x in workload_cfgs])
 
-        if args.batch_size_override is not None:
+        if parsed_args.batch_size_override is not None:
             for cfg in workload_cfgs:
-                cfg.dataset_cfg.batch_size = args.batch_size_override
-            logger.warning("Batch size override: {}", args.batch_size_override)
+                cfg.dataset_cfg.batch_size = parsed_args.batch_size_override
+            logger.warning("Batch size override: {}", parsed_args.batch_size_override)
 
-        if args.num_batches_override is not None:
+        if parsed_args.num_batches_override is not None:
             for cfg in workload_cfgs:
-                cfg.dataset_cfg.num_batches = args.num_batches_override
-            logger.warning("Num batches override: {}", args.num_batches_override)
+                cfg.dataset_cfg.num_batches = parsed_args.num_batches_override
+            logger.warning("Num batches override: {}", parsed_args.num_batches_override)
 
         return workload_cfgs
 

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.9.0"
+VERSION = "0.10.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/ai_workload.py
+++ b/simple_ai_benchmarking/workloads/ai_workload.py
@@ -61,6 +61,10 @@ class AIWorkload(ABC):
     def prepare_execution(self) -> None:
         pass
 
+    def sync_device(self) -> None:
+        """Synchronize the hardware accelerator device (no-op by default)."""
+        pass
+
     def execute(self) -> None:
         assert self.warmup_done, "Warmup not done before execution."
         self._execute()

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -187,8 +187,12 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
         if self.cfg.model_params == 0:
             self.cfg.model_params = sum(p.numel() for p in self._model.parameters())
 
-    def _sync_device(self) -> None:
-        """Block until queued accelerator work has finished so timing is real."""
+    def sync_device(self) -> None:
+        """Block until queued accelerator work has finished so timing is real.
+
+        Overrides the base ``AIWorkload.sync_device`` no-op; the generic
+        benchmark loop calls this on the public name, and the LLM timing paths
+        call it internally too, so both share one mechanism."""
         if self._device.type == "mps":
             self._torch.mps.synchronize()
         elif self._device.type == "cuda":
@@ -212,13 +216,13 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
         # time-to-first-token is a real measurement, not full-generation latency.
         start = time.perf_counter()
         sequence = self._model.generate(input_ids, 1)
-        self._sync_device()
+        self.sync_device()
         time_to_first_token_s = time.perf_counter() - start
 
         remaining_tokens = generated_tokens - 1
         if remaining_tokens > 0:
             self._model.generate(sequence, remaining_tokens)
-            self._sync_device()
+            self.sync_device()
 
         return [
             GenerationRequestResult(
@@ -410,12 +414,12 @@ class PyTorchKVDecoderGeneration(_DtypeQuantGeneration):
         # Prefill (= time-to-first-token), then cached single-token decode steps.
         start = time.perf_counter()
         next_token, cache = self._model.prefill(input_ids)
-        self._sync_device()
+        self.sync_device()
         time_to_first_token_s = time.perf_counter() - start
 
         for _ in range(generated_tokens - 1):
             next_token, cache = self._model.decode_step(next_token, cache)
-        self._sync_device()
+        self.sync_device()
 
         return [
             GenerationRequestResult(
@@ -496,7 +500,7 @@ class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
             outputs = self._model(input_ids=input_ids, use_cache=True)
             past = outputs.past_key_values
             next_token = outputs.logits[:, -1:, :].argmax(dim=-1)
-            self._sync_device()
+            self.sync_device()
             time_to_first_token_s = time.perf_counter() - start
 
             for _ in range(generated_tokens - 1):
@@ -505,7 +509,7 @@ class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
                 )
                 past = outputs.past_key_values
                 next_token = outputs.logits[:, -1:, :].argmax(dim=-1)
-            self._sync_device()
+            self.sync_device()
 
         return [
             GenerationRequestResult(

--- a/simple_ai_benchmarking/workloads/pytorch_workload.py
+++ b/simple_ai_benchmarking/workloads/pytorch_workload.py
@@ -71,7 +71,7 @@ class PyTorchTraining(AIWorkload):
         major_version = int(version_str.split(".")[0])
 
         if major_version >= 2 and platform.system() != "Windows":
-            torch.compile(self.model)
+            self.model = torch.compile(self.model)
 
     def _assign_numerical_precision(self) -> None:
 
@@ -89,6 +89,13 @@ class PyTorchTraining(AIWorkload):
     # TODO: what happens if device is other than cuda?
     def _assign_autocast_device_type(self) -> None:
         self.autocast_device_type = "cuda" if "cuda" in self.cfg.device_name else "cpu"
+
+    def sync_device(self) -> None:
+        if hasattr(self, "device"):
+            if self.device.type == "cuda" and torch.cuda.is_available():
+                torch.cuda.synchronize(self.device)
+            elif self.device.type == "mps" and hasattr(torch, "mps") and torch.backends.mps.is_available():
+                torch.mps.synchronize()
 
     def _get_model_parameters(self) -> int:
         return sum(p.numel() for p in self.model.parameters())
@@ -304,13 +311,13 @@ class PyTorchInference(PyTorchTraining):
             ):
                 self._infer_loop(dataloader)
 
-    # TODO: use loop that is similar to real world usage (no dataloader, more like webcam image stream etc.)
     def _infer_loop(self, dataloader: DataLoader) -> None:
         self.model.eval()
 
-        for inputs, labels in dataloader:
-            inputs, labels = inputs.to(self.device), labels.to(self.device)
-            outputs = self.model(inputs)
+        with torch.inference_mode():
+            for inputs, labels in dataloader:
+                inputs, labels = inputs.to(self.device), labels.to(self.device)
+                outputs = self.model(inputs)
 
     def _calculate_iterations(self) -> int:
         return self.cfg.dataset_cfg.num_batches * self.cfg.dataset_cfg.batch_size

--- a/simple_ai_benchmarking/workloads/tensorflow_workload.py
+++ b/simple_ai_benchmarking/workloads/tensorflow_workload.py
@@ -114,6 +114,10 @@ class TensorFlowTraining(AIWorkload):
             self.cfg.dataset_cfg
         )
 
+    def sync_device(self) -> None:
+        """Keras fit/predict calls used here block before returning."""
+        pass
+
     def _execute(self) -> None:
         self._train_loop(self.tf_dataset_execution, self.cfg.epochs)
 

--- a/tests/test_benchmark_dispatcher.py
+++ b/tests/test_benchmark_dispatcher.py
@@ -30,7 +30,7 @@ def test_pt_benchmark() -> None:
     dispatcher.REPETITIONS = 1
     dispatcher.NUM_BATCHES_INFERENCE = 5
     dispatcher.NUM_BATCHES_TRAINING = 3
-    dispatcher.run()
+    dispatcher.run(args=[])
 
 
 def test_tf_benchmark() -> None:
@@ -42,7 +42,7 @@ def test_tf_benchmark() -> None:
     dispatcher.REPETITIONS = 1
     dispatcher.NUM_BATCHES_INFERENCE = 5
     dispatcher.NUM_BATCHES_TRAINING = 3
-    dispatcher.run()
+    dispatcher.run(args=[])
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_dispatcher.py
+++ b/tests/test_benchmark_dispatcher.py
@@ -21,30 +21,31 @@ from simple_ai_benchmarking.entrypoints import BenchmarkDispatcher
 from simple_ai_benchmarking.config_structures import AIFramework
 
 
-def test_pt_benchmark() -> None:
+# Smallest possible smoke test of the full dispatch pipeline. The default config
+# builds 3 models x (inference + training); ResNet50/ViT-B-16 are heavy and may
+# download weights, so restrict to the lightweight SIMPLE_CLASSIFICATION_CNN via
+# "-w 0 1" (index 0 = inference, 1 = training) and run a single tiny batch.
+_FAST_ARGS = ["-w", "0", "1"]
 
-    dispatcher = BenchmarkDispatcher(AIFramework.PYTORCH)
-    dispatcher.NUM_BATCHES_INFERENCE = 2
-    dispatcher.NUM_BATCHES_TRAINING = 2
-    dispatcher.BATCH_SIZE = 2
+
+def _make_fast_dispatcher(framework: AIFramework) -> BenchmarkDispatcher:
+    dispatcher = BenchmarkDispatcher(framework)
+    dispatcher.BATCH_SIZE = 1
     dispatcher.REPETITIONS = 1
-    dispatcher.NUM_BATCHES_INFERENCE = 5
-    dispatcher.NUM_BATCHES_TRAINING = 3
-    dispatcher.run(args=[])
+    dispatcher.NUM_BATCHES_INFERENCE = 1
+    dispatcher.NUM_BATCHES_TRAINING = 1
+    return dispatcher
+
+
+def test_pt_benchmark() -> None:
+    _make_fast_dispatcher(AIFramework.PYTORCH).run(args=_FAST_ARGS)
 
 
 def test_tf_benchmark() -> None:
-
-    dispatcher = BenchmarkDispatcher(AIFramework.TENSORFLOW)
-    dispatcher.NUM_BATCHES_INFERENCE = 2
-    dispatcher.NUM_BATCHES_TRAINING = 2
-    dispatcher.BATCH_SIZE = 2
-    dispatcher.REPETITIONS = 1
-    dispatcher.NUM_BATCHES_INFERENCE = 5
-    dispatcher.NUM_BATCHES_TRAINING = 3
-    dispatcher.run(args=[])
+    _make_fast_dispatcher(AIFramework.TENSORFLOW).run(args=_FAST_ARGS)
 
 
 if __name__ == "__main__":
     test_pt_benchmark()
     test_tf_benchmark()
+

--- a/tests/test_benchmark_metadata.py
+++ b/tests/test_benchmark_metadata.py
@@ -1,7 +1,9 @@
 import pytest
 
 from simple_ai_benchmarking.benchmark_metadata import (
+    SPEC_VERSION,
     build_cv_profile,
+    build_cv_profile_id,
     build_llm_profile,
     canonical_hash,
 )
@@ -121,6 +123,20 @@ def test_cv_profile_hash_changes_for_workload_parameters_only():
     assert canonical_hash(base) == canonical_hash(
         {key: with_runtime_noise[key] for key in base}
     )
+
+
+def test_cv_profile_id_matches_spec_major_version():
+    profile = build_cv_profile(
+        workload_type="InferenceWorkload",
+        model="ResNet50",
+        compute_precision="DEFAULT_PRECISION",
+        batch_size=32,
+        sample_shape=[224, 224, 3],
+        num_classes=1000,
+    )
+
+    spec_major = SPEC_VERSION.split(".", 1)[0]
+    assert build_cv_profile_id(profile).endswith(f"_v{spec_major}")
 
 
 def test_llm_profile_hash_changes_for_comparability_parameters():

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,53 @@
+import queue as queue_mod
+
+from simple_ai_benchmarking.benchmark import _extract_repetition_result
+from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
+from simple_ai_benchmarking.workloads.llm_workload import PyTorchLocalGeneration
+
+
+class _FakeQueue:
+    """Minimal stand-in for multiprocessing.Queue used to test result handling
+    without spawning real processes."""
+
+    def __init__(self, value=None, raises=None):
+        self._value = value
+        self._raises = raises
+        self.get_called = False
+
+    def get(self, timeout=None):
+        self.get_called = True
+        if self._raises is not None:
+            raise self._raises
+        return self._value
+
+
+def test_extract_result_returns_queue_value_on_clean_exit():
+    sentinel = object()
+    fake_queue = _FakeQueue(value=sentinel)
+
+    assert _extract_repetition_result(0, fake_queue) is sentinel
+
+
+def test_extract_result_is_runtimeerror_on_nonzero_exit():
+    fake_queue = _FakeQueue(value="should-not-be-read")
+
+    result = _extract_repetition_result(1, fake_queue)
+
+    assert isinstance(result, RuntimeError)
+    # A crashed child must not cause us to block on (or read from) the queue.
+    assert not fake_queue.get_called
+
+
+def test_extract_result_is_runtimeerror_on_empty_queue():
+    fake_queue = _FakeQueue(raises=queue_mod.Empty())
+
+    result = _extract_repetition_result(0, fake_queue)
+
+    assert isinstance(result, RuntimeError)
+
+
+def test_llm_workload_unifies_on_public_sync_device():
+    # The LLM path overrides the public sync_device hook (no private duplicate),
+    # so the generic benchmark loop and the internal timing share one mechanism.
+    assert PyTorchLocalGeneration.sync_device is not AIWorkload.sync_device
+    assert not hasattr(PyTorchLocalGeneration, "_sync_device")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -176,6 +176,80 @@ class TestPublishDatabase(unittest.TestCase):
             os.remove(csv_path)
 
 
+class TestSubmissionOutcomes(unittest.TestCase):
+
+    class _Resp:
+        def __init__(self, status_code, text=""):
+            self.status_code = status_code
+            self.text = text
+
+    class _Data:
+        def to_dict(self):
+            return {"benchmark_profile_hash": "abc"}
+
+    def test_classify_submission_outcomes(self):
+        from simple_ai_benchmarking import database as db
+
+        self.assertEqual(
+            db._classify_submission(self._Data(), self._Resp(201)), db.SUBMIT_CREATED
+        )
+        self.assertEqual(
+            db._classify_submission(self._Data(), self._Resp(409)), db.SUBMIT_DUPLICATE
+        )
+        self.assertEqual(
+            db._classify_submission(self._Data(), self._Resp(400, "boom")),
+            db.SUBMIT_FAILED,
+        )
+
+    def test_unknown_profile_failure_prints_register_hint(self):
+        import io
+        from contextlib import redirect_stdout
+        from simple_ai_benchmarking import database as db
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            db._report_submission_failure(
+                self._Data(), self._Resp(400, "Unknown benchmark profile hash.")
+            )
+        self.assertIn("saib-register", buf.getvalue())
+
+    def test_submit_results_skips_duplicates_and_continues(self):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from simple_ai_benchmarking import database as db
+
+        outcomes = iter([db.SUBMIT_CREATED, db.SUBMIT_DUPLICATE, db.SUBMIT_CREATED])
+        attempted = []
+
+        def fake_submit(data, submit_url, api_token):
+            attempted.append(data)
+            return next(outcomes)
+
+        with patch.object(db, "submit_benchmark_result_token_auth", fake_submit):
+            db.submit_results(["a", "b", "c"], SimpleNamespace(), "http://x", "tok")
+
+        # The duplicate ("b") is skipped without aborting; "c" still gets published.
+        self.assertEqual(attempted, ["a", "b", "c"])
+
+    def test_submit_results_stops_on_hard_failure(self):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        from simple_ai_benchmarking import database as db
+
+        outcomes = iter([db.SUBMIT_CREATED, db.SUBMIT_FAILED, db.SUBMIT_CREATED])
+        attempted = []
+
+        def fake_submit(data, submit_url, api_token):
+            attempted.append(data)
+            return next(outcomes)
+
+        with patch.object(db, "submit_benchmark_result_token_auth", fake_submit):
+            db.submit_results(["a", "b", "c"], SimpleNamespace(), "http://x", "tok")
+
+        # A genuine failure still aborts: "c" is never attempted.
+        self.assertEqual(attempted, ["a", "b"])
+
+
 # Entry point for running the tests
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Why:** Address the P0/P1 findings from the repo review: a benchmark run could hang or silently misreport, CV metrics were not comparable across frameworks, and publishing aborted on recoverable conditions.

**What:**
- Benchmark execution: detect child-process crashes (exit code) and cap the result-queue wait so a dead child can't hang the run; extract `_extract_repetition_result` for testability.
- CV validity: synchronize the accelerator before stopping the timer, wrap PyTorch inference in `torch.inference_mode()`, fix the no-op `torch.compile` assignment, and generate synthetic targets using the real `num_classes`.
- Versioning: bump CV spec to v2 / `saib.cv.classification.v2` and derive the profile id major version dynamically (correctness fixes make v1 results non-comparable).
- CLI: thread `args` through `BenchmarkDispatcher.run`/`_override_workload_cfg` so the parser no longer reads pytest's argv.
- Device sync: unify on the public `sync_device` hook (LLM `_sync_device` renamed) so the generic loop and LLM timing share one mechanism.
- Publish robustness: classify submissions (created/duplicate/failed); skip 409 duplicates and keep publishing the rest; hint to run `saib-register` when the server rejects an unregistered profile hash.
- Docs: add a copyable `simple-ai-benchmarking[pt,lowbit]` quick install.
- Tests: cover result extraction, sync unification, submission outcomes, duplicate-skip, the register hint, and the CV profile-id version; speed up the dispatcher smoke tests (restrict to the lightweight CNN + single tiny batch).

**Test:** `.venv/bin/python -m pytest tests/ -q` → 57 passed, 4 skipped in ~17s.