### PR TITLE
fix: bundle Qwen3 config so HF LLM backends build offline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TimoIllusion/simple-ai-benchmarking",
     packages=setuptools.find_packages(),
+    # Ship bundled HF model configs (e.g. Qwen3) so the LLM backends build their
+    # architecture offline instead of fetching config.json from huggingface.co.
+    package_data={"simple_ai_benchmarking": ["model_configs/*/config.json"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/simple_ai_benchmarking/model_configs/Qwen__Qwen3-1.7B/config.json
+++ b/simple_ai_benchmarking/model_configs/Qwen__Qwen3-1.7B/config.json
@@ -1,0 +1,30 @@
+{
+  "architectures": [
+    "Qwen3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151643,
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 6144,
+  "max_position_embeddings": 40960,
+  "max_window_layers": 28,
+  "model_type": "qwen3",
+  "num_attention_heads": 16,
+  "num_hidden_layers": 28,
+  "num_key_value_heads": 8,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": true,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0",
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -19,6 +19,7 @@
 
 import datetime
 import json
+import os
 import time
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -34,6 +35,21 @@ from simple_ai_benchmarking.llm_results import (
 )
 from simple_ai_benchmarking.results import collect_hw_info, collect_sw_info
 from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
+
+# Model configs bundled with the package, keyed by HF repo id with "/" -> "__".
+# Used so the default HF causal backends build their architecture fully offline
+# instead of fetching config.json from huggingface.co, which rate-limits/blocks
+# datacenter IPs (the failure that silently dropped all Qwen LLM results).
+_BUNDLED_CONFIG_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "model_configs")
+
+
+def _resolve_config_source(model_id: str) -> str:
+    """Return a local bundled config directory for known model ids, else the HF
+    repo id (so custom --model values still resolve over the network)."""
+    bundled = os.path.join(_BUNDLED_CONFIG_DIR, model_id.replace("/", "__"))
+    if os.path.isfile(os.path.join(bundled, "config.json")):
+        return os.path.abspath(bundled)
+    return model_id
 
 
 PYTORCH_GENERATION_BACKEND = "pytorch-simple-transformer"
@@ -468,7 +484,7 @@ class HuggingFaceCausalGeneration(_DtypeQuantGeneration):
         self._device = torch.device(self.cfg.device_name)
         dtype = self._resolve_base_dtype()
 
-        config = AutoConfig.from_pretrained(self.cfg.model)
+        config = AutoConfig.from_pretrained(_resolve_config_source(self.cfg.model))
         self._vocab_size = config.vocab_size
         try:
             model = AutoModelForCausalLM.from_config(config, torch_dtype=dtype)


### PR DESCRIPTION
**Why:** The default `huggingface-causal` / `-fp8` / `-fp4` backends call `AutoConfig.from_pretrained("Qwen/Qwen3-1.7B")`, which fetches `config.json` from huggingface.co. From datacenter IPs (e.g. RunPod) that request is frequently rate-limited/blocked (`Can't load the configuration of 'Qwen/Qwen3-1.7B'`), so all three Qwen backends failed and only the two local LLM backends published their results.

**What:**
- Bundle `Qwen3-1.7B/config.json` in the package under `simple_ai_benchmarking/model_configs/Qwen__Qwen3-1.7B/`.
- `_resolve_config_source()` in `llm_workload` resolves known model ids to the bundled config first; custom `--model` values still resolve over the network.
- Ship `model_configs/*/config.json` via `package_data` (verified present in the built wheel).
- These backends use random weights (config only, no checkpoint), so the bundled config fully builds the architecture offline.

**Test:**
- `python -m pytest tests/` -> 75 passed.
- `HF_HUB_OFFLINE=1` load of the bundled config parses `model_type=qwen3` (hidden 2048, 28 layers, vocab 151936).
- `uv build --wheel` -> wheel contains `simple_ai_benchmarking/model_configs/Qwen__Qwen3-1.7B/config.json`.