### PR TITLE
refactor: replace SSH runpod runner with no-SSH REST launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,34 +226,57 @@ It deduplicates by `benchmark_profile_hash` (each distinct profile is registered
 
 ### Experimental: run on a throwaway RunPod GPU pod
 
-`saib-runpod` runs the whole loop on a rented [RunPod](https://www.runpod.io/) GPU and **always terminates the pod afterwards** (even on error or Ctrl-C): it creates an on-demand pod, connects over SSH, installs SAIB, runs the benchmark, registers + publishes the results, then tears the pod down. This is experimental and unsupported — capacity is best-effort and you are billed per second while a pod runs.
+`saib-runpod` runs the whole loop on a rented [RunPod](https://www.runpod.io/) GPU and the pod **self-terminates when it is done** (on success, crash, or a hung step that hits its timeout). It creates an on-demand pod whose **container start command** installs SAIB, runs the benchmark(s), registers + publishes the results, then deletes the pod. This is experimental and unsupported — capacity is best-effort and you are billed per second while a pod runs.
 
-It uses your system OpenSSH client (no extra SSH library), so the only optional dependency is the RunPod SDK:
+**No SSH.** The benchmark is driven entirely by the pod's `dockerStartCmd` (sent to the RunPod **REST API v1** as a `["bash","-lc", <script>]` array). Nothing connects back to the pod, so:
 
-```bash
-pip install simple-ai-benchmarking[runpod]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git
-```
+- It works on RunPod **secure cloud** (which usually exposes no public IP) just as well as community cloud — no public IP, no SSH key, no ssh-agent needed.
+- The launch call returns immediately; your machine can disconnect while the pod runs and tears itself down on its own.
+- The only dependency is Python stdlib (`urllib`) — the RunPod SDK is **not** required. (The `[runpod]` extra still exists for your own scripting, but `saib-runpod` doesn't need it.)
 
-Prerequisites:
-
-- A **RunPod API key** (`RUNPOD_API_KEY`).
-- An **SSH key registered in your RunPod account** (Account → Settings → SSH Public Keys). RunPod injects that key into the pod. Point `--ssh-key` at the matching private key.
-- If that private key is **passphrase-protected, load it into ssh-agent first** (`ssh-add ~/.ssh/your_key`) — otherwise SSH can't authenticate non-interactively and the run aborts (the tool preflight-checks this *before* creating a pod, so it won't waste money).
-
-Then:
+The pod self-terminates via a shell `trap` that issues `DELETE /v1/pods/$RUNPOD_POD_ID` (the API key is provided to the pod as an env var for exactly this). A per-step `timeout` guard means a hung `saib-pt`/`saib-llm` can't keep the pod alive forever, and thread caps (`OMP/BLAS=8`) are set before any import to avoid host-core oversubscription.
 
 ```bash
 export RUNPOD_API_KEY=YOUR_RUNPOD_KEY
 export AI_BENCHMARK_DATABASE_TOKEN=YOUR_DATABASE_TOKEN
-ssh-add ~/.ssh/id_ed25519              # if your key has a passphrase
-saib-runpod --ssh-key ~/.ssh/id_ed25519 --gpu "NVIDIA GeForce RTX 4090" --cloud-type COMMUNITY
+saib-runpod --gpu "NVIDIA GeForce RTX 4090"          # CV + LLM, image auto-selected
+saib-runpod --gpu "NVIDIA B200" --workload llm         # Blackwell -> FP8+FP4 auto
+saib-runpod --dry-run --gpu "NVIDIA B200"              # print plan + container script, no API key
 ```
 
-If `RUNPOD_API_KEY` or `AI_BENCHMARK_DATABASE_TOKEN` are not set (and not passed via `--api-key`/`--db-token`), you are prompted to paste them interactively (hidden input). In a non-interactive shell (e.g. CI or a background job) it errors instead of hanging, so supply them via env/flags there.
+If `RUNPOD_API_KEY` or `AI_BENCHMARK_DATABASE_TOKEN` are not set (and not passed via `--api-key`/`--db-token`), you are prompted to paste them interactively (hidden input). In a non-interactive shell it errors instead of hanging, so supply them via env/flags there.
 
-**GPU names** are the RunPod GPU *ids*, e.g. `NVIDIA GeForce RTX 4090`, `NVIDIA H100 80GB HBM3` (H100 SXM), `NVIDIA H200` (H200 SXM) — not the short display names. The runner connects over the pod's direct public IP, which **community cloud** provides reliably (secure cloud often has no public IP); prefer `--cloud-type COMMUNITY`.
+**Image and low-bit are auto-selected per GPU generation** (this is "lowbit only on respective GPUs and images"):
 
-Useful flags: `--workload pt|tf|llm`, `--gpu "A,B,C"` (comma-separated fallback list tried in order), `--cloud-type COMMUNITY|SECURE|ALL`, `--capacity-wait SECONDS` (keep retrying the requested GPU(s) with backoff while RunPod has no capacity), `--ssh-timeout`/`--run-timeout SECONDS`, `--extra-args "-w 0 1"` (passed to the benchmark command), `--no-publish`, `--keep` (leave the pod running for debugging — you must then terminate it yourself), and `--dry-run` (print the plan and the exact remote script without creating anything — no API key needed). The database token is sent to the pod over the encrypted SSH channel, not baked into any image or argument string.
+| GPU generation | Image | pip extra | Default LLM `-w` | Low-bit |
+|---|---|---|---|---|
+| **Blackwell** (B200, RTX 5090, RTX PRO Blackwell) | `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` (torch 2.8 / CUDA 12.8) | `[pt,lowbit]` | `0 1 2 3 4` | **FP8 + FP4** |
+| **Everything else** (Hopper, Ada, Ampere, …) | `runpod/pytorch:2.4.0-...cuda12.4.1` (torch 2.4) | `[pt]` | `0 1 2` | none |
+
+Blackwell is special-cased automatically because it *cannot* run on the torch 2.4 image at all. **FP8 on Hopper/Ada is opt-in**, not automatic: it needs the torch 2.8 image too, but that image requires a host driver ≥ 12.8 and can fail to start on older-driver non-Blackwell hosts. Enable it explicitly (prefer SECURE/datacenter hosts):
+
+```bash
+saib-runpod --gpu "NVIDIA H100 80GB HBM3" --cloud-type SECURE \
+  --image runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404 \
+  --pip-spec "simple-ai-benchmarking[pt,lowbit]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git@main" \
+  --llm-args "-w 0 1 2 3"     # FP8 yes, FP4 no (Hopper/Ada have no FP4)
+```
+
+> ⚠️ Never pair `[pt,lowbit]` with the torch 2.4 image — torchao is unpinned and won't resolve there, which **aborts the whole install** so nothing runs. The auto-selection above guarantees this pairing never happens; only override it knowingly.
+
+**GPU names** are the RunPod GPU *ids*, e.g. `NVIDIA GeForce RTX 4090`, `NVIDIA H100 80GB HBM3` (H100 SXM), `NVIDIA H200`, `NVIDIA B200` — not the short display names. List them with `python -c "import runpod,os; runpod.api_key=os.environ['RUNPOD_API_KEY']; print('\n'.join(g['id'] for g in runpod.get_gpus()))"`.
+
+Useful flags: `--workload pt|llm|both` (default `both`), `--gpu "A,B,C"` (comma-separated fallback list; RunPod picks by availability), `--cloud-type SECURE|COMMUNITY` (default `SECURE`), `--capacity-wait SECONDS` (keep retrying while RunPod has no capacity, with backoff), `--image`/`--pip-spec` (override the auto profile), `--pt-args`/`--llm-args "-w 0 1 2"` (passed to the benchmark commands), `--pt-timeout`/`--llm-timeout SECONDS` (per-step hang caps), `--no-publish`, `--keep` (do **not** self-terminate — you must delete the pod yourself), and `--dry-run` (print the plan and the exact container script without creating anything — no API key needed). The database token is provided to the pod as an env var, never baked into the image or the script string.
+
+#### Launch a whole fleet
+
+`tools/run_fleet.sh` fires a spread of GPUs in one go (each a self-terminating CV+LLM pod), with the low-bit matrix applied per generation — Blackwell auto, FP8 opt-in on Hopper/Ada, none on Ampere:
+
+```bash
+export RUNPOD_API_KEY=...  AI_BENCHMARK_DATABASE_TOKEN=...
+tools/run_fleet.sh                       # default 5-GPU spread
+FP8_ON_HOPPER_ADA=0 tools/run_fleet.sh   # skip the torch 2.8 FP8 opt-in (most reliable)
+```
 
 ## Hardware Acceleration for PyTorch and TensorFlow
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,9 @@ setuptools.setup(
         # instead. This extra may break as torchao evolves.
         "lowbit": ["torchao"],
         # Optional: experimental one-shot benchmarking on a RunPod GPU pod.
-        # (SSH uses the system OpenSSH client, so only the RunPod SDK is needed.)
+        # saib-runpod now talks to the RunPod REST API over stdlib urllib (no SSH,
+        # no SDK), so this extra is no longer required to use it -- kept for anyone
+        # who wants the SDK for their own scripting.
         "runpod": ["runpod"],
         "tfdml": ["tensorflow-cpu==2.10.0", "tensorflow-directml-plugin"],
         "tf": ["tensorflow>=2.3.0"],

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -16,343 +16,315 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Experimental one-shot benchmark runner on a RunPod GPU pod.
+"""Experimental fire-and-forget benchmark runner on a throwaway RunPod GPU pod.
 
-It does the whole loop for you and *always* tears the pod down again:
+It creates an on-demand GPU pod whose **container start command** (passed to the
+RunPod REST API v1 as a ``dockerStartCmd`` array) installs SAIB, runs the
+benchmark(s), publishes the results to the database over HTTPS, and then
+**self-terminates the pod** via a shell ``trap`` -- on success, crash, or a hung
+step that hits its ``timeout``. There is no SSH: nothing connects back to the pod,
+so it works on RunPod **secure cloud** (which usually exposes no public IP) just as
+well as community cloud, and the local machine can disconnect immediately after the
+create call returns.
 
-    1. create an on-demand GPU pod (with SSH enabled and your public key),
-    2. wait until SSH is reachable,
-    3. install SAIB, run the benchmark, and publish results to the database,
-    4. terminate the pod (even on error or Ctrl-C).
+Why no SSH (the previous design): driving the run over SSH required the pod to
+expose a public IP (secure-cloud pods often don't), a registered SSH key, an
+ssh-agent dance for passphrase keys, and a local process that stayed connected for
+the whole run. Pushing the work into ``dockerStartCmd`` removes all of that: the
+pod is autonomous and tears itself down.
 
-This is deliberately small and dependency-light. It is NOT a managed service:
-capacity is best-effort, and you are billed per second while the pod runs, so
-the guaranteed teardown is the whole point.
-
-Usage (CV example)::
+Usage::
 
     export RUNPOD_API_KEY=...                 # from runpod.io account settings
     export AI_BENCHMARK_DATABASE_TOKEN=...     # database API token
-    saib-runpod --gpu "NVIDIA GeForce RTX 4090"
+    saib-runpod --gpu "NVIDIA GeForce RTX 4090"          # CV + LLM, auto image
+    saib-runpod --gpu "NVIDIA B200" --workload llm        # Blackwell -> FP8+FP4 auto
 
-Dry run (no API key needed, prints the plan and remote script)::
+Dry run (no API key needed, prints the plan and the exact container script)::
 
-    saib-runpod --dry-run
+    saib-runpod --dry-run --gpu "NVIDIA B200"
 
-Install the optional dependencies with::
+Install the optional dependency (the RunPod SDK is NOT required -- this uses the
+REST API over stdlib ``urllib`` -- but installing the extra is harmless)::
 
     pip install simple-ai-benchmarking[runpod]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git
+
+To launch a whole fleet of GPUs in one go, see ``tools/run_fleet.sh``.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
-import signal
-import subprocess
 import sys
 import time
-from dataclasses import dataclass
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-DEFAULT_IMAGE = "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"
-DEFAULT_GPUS = "NVIDIA GeForce RTX 4090"
+REST_BASE = "https://rest.runpod.io/v1"
 DEFAULT_DATABASE_URL = "https://timoillusion.pythonanywhere.com"
-DEFAULT_PIP_SPEC = (
+
+# Image per GPU generation.
+#  - torch 2.4 / CUDA 12.4 works for everything up to Hopper (sm_90) and is widely
+#    cached, so it is the safe default.
+#  - Blackwell (sm_100 B200/B300, sm_120 RTX 50xx / RTX PRO Blackwell) is NOT
+#    supported by torch 2.4 / CUDA 12.4 at all and needs torch >= 2.7 + CUDA 12.8.
+DEFAULT_IMAGE = "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"
+BLACKWELL_IMAGE = "runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404"
+
+# The lowbit extra pulls in torchao for real FP8/FP4 kernels. torchao is unpinned
+# and tracks recent torch, so installing it on the torch 2.4 image FAILS and aborts
+# the whole install -- hence lowbit is only ever paired with the Blackwell (torch
+# 2.8) image here. FP8/FP4 aren't usable on the torch 2.4 generation anyway.
+PIP_BASE = (
     "simple-ai-benchmarking[pt]@git+"
     "https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
 )
-DONE_MARKER = "SAIB_RUNPOD_DONE"
+PIP_LOWBIT = (
+    "simple-ai-benchmarking[pt,lowbit]@git+"
+    "https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
+)
 
-# Per-workload: (run command, results CSV, publish command).
-WORKLOADS = {
-    "pt": ("saib-pt", "results_pt.csv", "saib-pub"),
-    "tf": ("saib-tf", "results_tf.csv", "saib-pub"),
-    "llm": ("saib-llm", "llm_results.csv", "saib-pub-llm"),
-}
+# RunPod gpuTypeId substrings that identify a Blackwell card. Matched case-folded.
+BLACKWELL_MARKERS = (
+    "B200",
+    "B300",
+    "RTX 5090",
+    "RTX 5080",
+    "RTX 5070",
+    "RTX PRO 6000 BLACKWELL",
+    "RTX PRO 5000 BLACKWELL",
+    "RTX PRO 4500 BLACKWELL",
+    "RTX PRO 4000 BLACKWELL",
+)
+
+# Default LLM workload index sets (mirrors `saib-llm` default order):
+#   0 simple-transformer, 1 kv-decoder, 2 huggingface-causal (Qwen BF16),
+#   3 huggingface-causal-fp8, 4 huggingface-causal-fp4.
+LLM_W_BLACKWELL = "0 1 2 3 4"  # FP8 + FP4
+LLM_W_NO_LOWBIT = "0 1 2"  # no FP8/FP4 (torch 2.4 / non-lowbit install)
+
+DONE_MARKER = "SAIB_ALL_DONE"
 
 
 def log(message: str) -> None:
     print(f"[saib-runpod {time.strftime('%H:%M:%S')}] {message}", flush=True)
 
 
+def is_blackwell(gpu_id: str) -> bool:
+    upper = gpu_id.upper()
+    return any(marker in upper for marker in BLACKWELL_MARKERS)
+
+
 @dataclass
 class Config:
-    api_key: str
+    api_key: Optional[str]
     db_token: Optional[str]
     gpus: List[str]
     image: str
-    workload: str
     pip_spec: str
+    workload: str  # "pt" | "llm" | "both"
+    pt_args: str
+    llm_args: str
     database_url: str
-    private_key_path: str
-    public_key: str
     disk_gb: int
     cloud_type: str
-    extra_args: str
     publish: bool
     keep: bool
     capacity_wait: int
-    create_timeout: int
-    ssh_timeout: int
-    run_timeout: int
+    pt_timeout: int
+    llm_timeout: int
+    image_was_set: bool = False
+    pip_was_set: bool = False
+    llm_args_was_set: bool = False
 
 
 # --------------------------------------------------------------------------- #
-# Remote script
+# Generation-aware defaults
 # --------------------------------------------------------------------------- #
-def build_remote_script(cfg: Config) -> str:
-    """The bash run on the pod. ``set -euo pipefail`` makes any failing step
-    abort with a non-zero exit code, which the orchestrator reports and which
-    still triggers teardown."""
-    run_cmd, results_csv, publish_cmd = WORKLOADS[cfg.workload]
-    run_line = run_cmd if not cfg.extra_args else f"{run_cmd} {cfg.extra_args}"
+def resolve_profile(cfg: Config) -> None:
+    """Fill image / pip-spec / LLM workload set from the *first* requested GPU's
+    generation, unless the user pinned them explicitly.
 
+    Only Blackwell is special-cased automatically, because Blackwell *cannot* run
+    on the default image at all -- so picking the torch 2.8 image + lowbit for it is
+    a correctness requirement, not a preference. Enabling FP8 on Hopper/Ada is left
+    opt-in (pass ``--image`` + ``--pip-spec`` / see ``tools/run_fleet.sh``) because
+    the torch 2.8 image needs a host driver >= 12.8 and can fail to start on
+    older-driver non-Blackwell hosts."""
+    lead = cfg.gpus[0] if cfg.gpus else ""
+    blackwell = is_blackwell(lead)
+
+    if not cfg.image_was_set:
+        cfg.image = BLACKWELL_IMAGE if blackwell else DEFAULT_IMAGE
+    if not cfg.pip_was_set:
+        cfg.pip_spec = PIP_LOWBIT if blackwell else PIP_BASE
+    if not cfg.llm_args_was_set:
+        # Only restrict the default set; respect an explicit --llm-args.
+        lowbit = "lowbit" in cfg.pip_spec
+        if blackwell:
+            cfg.llm_args = f"-w {LLM_W_BLACKWELL}"
+        elif lowbit:
+            cfg.llm_args = "-w 0 1 2 3"  # FP8 but not FP4
+        else:
+            cfg.llm_args = f"-w {LLM_W_NO_LOWBIT}"
+
+
+# --------------------------------------------------------------------------- #
+# Container start script (runs ON the pod, exec'd by bash via dockerStartCmd)
+# --------------------------------------------------------------------------- #
+_THREAD_CAPS = r"""export DEBIAN_FRONTEND=noninteractive
+# Cap BLAS/OMP threads: a pod is a container on a big host, so numpy/OpenBLAS/MKL/
+# torch otherwise spawn one thread per HOST core (often 100+) on a few allocated
+# vCPUs -> oversubscription that looks like a hang. Must be set before any import.
+export OMP_NUM_THREADS=8
+export OPENBLAS_NUM_THREADS=8
+export MKL_NUM_THREADS=8
+export NUMEXPR_NUM_THREADS=8
+export VECLIB_MAXIMUM_THREADS=8
+export TOKENIZERS_PARALLELISM=false
+command -v git >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq git) || true
+cd /workspace 2>/dev/null || cd /root 2>/dev/null || cd /"""
+
+_SELF_TERMINATE = r"""SAIB_TERMINATED=0
+cleanup() {
+  [ "$SAIB_TERMINATED" = "1" ] && return
+  SAIB_TERMINATED=1
+  echo "== SAIB self-terminating pod ${RUNPOD_POD_ID} =="
+  # python is present in all pytorch images, so teardown needs no curl.
+  python -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" \
+  || python3 -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" || true
+  # Block so the container does NOT exit and get auto-restarted by RunPod before the
+  # DELETE takes effect -- an exited container is restarted and the whole benchmark
+  # re-runs in a loop (duplicate rows + runaway billing).
+  sleep 900
+}
+trap cleanup EXIT"""
+
+
+def _pt_block(cfg: Config) -> str:
+    args = f" {cfg.pt_args}" if cfg.pt_args else ""
     lines = [
-        "set -euo pipefail",
-        "export DEBIAN_FRONTEND=noninteractive",
-        'echo "== installing SAIB =="',
-        "python -m pip install --upgrade pip",
-        f'pip install "{cfg.pip_spec}"',
-        'echo "== running benchmark =="',
-        run_line,
+        'echo "== [pt] running (timeout ${PT_TIMEOUT}s) =="',
+        f'timeout -k 60 "${{PT_TIMEOUT}}" saib-pt{args} || echo "WARN saib-pt rc=$?"',
     ]
-
     if cfg.publish:
-        # Token is exported here (transmitted over the encrypted SSH channel) and
-        # referenced via the variable, so it is not baked into the pip spec.
-        common = (
-            f'-t "$AI_BENCHMARK_DATABASE_TOKEN" '
-            f'--database-url "{cfg.database_url}" --non-interactive'
-        )
         lines += [
-            'echo "== registering profiles =="',
-            f"saib-register {results_csv} {common}",
-            'echo "== publishing results =="',
-            f"{publish_cmd} {results_csv} {common}",
+            'saib-register results_pt.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN register pt"',
+            'saib-pub results_pt.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN pub pt"',
         ]
-    else:
-        lines.append('echo "== publish skipped (--no-publish) =="')
-
-    lines.append(f'echo "{DONE_MARKER}"')
     return "\n".join(lines)
 
 
-# --------------------------------------------------------------------------- #
-# RunPod lifecycle
-# --------------------------------------------------------------------------- #
-def _import_runpod():
-    try:
-        import runpod  # type: ignore
-    except ImportError as exc:  # pragma: no cover - exercised only without deps
-        raise SystemExit(
-            "The 'runpod' package is required. Install with: "
-            "pip install simple-ai-benchmarking[runpod]"
-        ) from exc
-    return runpod
+def _llm_block(cfg: Config) -> str:
+    args = f" {cfg.llm_args}" if cfg.llm_args else ""
+    lines = [
+        'echo "== [llm] running (timeout ${LLM_TIMEOUT}s) =="',
+        f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm{args} || echo "WARN saib-llm rc=$?"',
+    ]
+    if cfg.publish:
+        lines += [
+            'saib-register llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN register llm"',
+            'saib-pub-llm llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN pub llm"',
+        ]
+    return "\n".join(lines)
 
 
-def _try_create_pod(runpod, cfg: Config, gpu: str) -> Optional[dict]:
-    pod = runpod.create_pod(
-        name=f"saib-{cfg.workload}-{int(time.time())}",
-        image_name=cfg.image,
-        gpu_type_id=gpu,
-        cloud_type=cfg.cloud_type,
-        gpu_count=1,
-        container_disk_in_gb=cfg.disk_gb,
-        volume_in_gb=0,
-        ports="22/tcp",
-        start_ssh=True,
-        support_public_ip=True,
-        env={
-            "PUBLIC_KEY": cfg.public_key,
-            "AI_BENCHMARK_DATABASE_TOKEN": cfg.db_token or "",
-        },
+def build_container_script(cfg: Config) -> str:
+    """The bash exec'd by the pod's dockerStartCmd. The DB token is read from the
+    pod env (``AI_BENCHMARK_DATABASE_TOKEN``), never interpolated into the text, so
+    it is not baked into the script string."""
+    blocks = [
+        _THREAD_CAPS,
+        _SELF_TERMINATE if not cfg.keep else 'echo "== --keep: pod will NOT self-terminate =="',
+        f'URL="{cfg.database_url}"',
+        f'PT_TIMEOUT="{cfg.pt_timeout}"',
+        f'LLM_TIMEOUT="{cfg.llm_timeout}"',
+        'echo "== installing SAIB =="',
+        "python -m pip install --upgrade pip",
+        f'pip install "{cfg.pip_spec}"',
+    ]
+    if cfg.workload in ("pt", "both"):
+        blocks.append(_pt_block(cfg))
+    if cfg.workload in ("llm", "both"):
+        blocks.append(_llm_block(cfg))
+    blocks.append(f'echo "{DONE_MARKER}"')
+    return "\n".join(blocks)
+
+
+# --------------------------------------------------------------------------- #
+# RunPod REST API
+# --------------------------------------------------------------------------- #
+def rest_call(method: str, path: str, key: str, body: Optional[dict] = None) -> Tuple[int, object]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        REST_BASE + path,
+        data=data,
+        method=method,
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
     )
-    if pod and pod.get("id"):
-        return pod
-    return None
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            txt = resp.read().decode()
+            return resp.status, (json.loads(txt) if txt else {})
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()[:600]
 
 
-def create_pod_with_fallback(runpod, cfg: Config) -> dict:
-    """Create a pod, trying each requested GPU in order.
+def build_pod_body(cfg: Config, script: str) -> dict:
+    env = {"RUNPOD_API_KEY": cfg.api_key}
+    if cfg.publish:
+        env["AI_BENCHMARK_DATABASE_TOKEN"] = cfg.db_token or ""
+    return {
+        "name": f"saib-{cfg.workload}-{int(time.time())}",
+        "imageName": cfg.image,
+        "computeType": "GPU",
+        "gpuTypeIds": list(cfg.gpus),
+        "gpuTypePriority": "availability",
+        "cloudType": cfg.cloud_type,
+        "gpuCount": 1,
+        "containerDiskInGb": cfg.disk_gb,
+        "volumeInGb": 0,
+        "supportPublicIp": False,
+        "dockerStartCmd": ["bash", "-lc", script],
+        "env": env,
+    }
 
-    GPU capacity on RunPod is transient, so when ``--capacity-wait`` is set we
-    keep retrying the same requested GPU list (with backoff) until a pod is
-    created or the budget elapses, instead of switching to some other GPU."""
+
+def create_pod_with_retry(cfg: Config, script: str) -> str:
+    """POST the pod, retrying on no-capacity while the ``--capacity-wait`` budget
+    lasts. The REST gpuTypeIds list is itself a fallback set tried by RunPod by
+    availability, so retrying re-attempts the whole list."""
     deadline = time.time() + max(0, cfg.capacity_wait)
-    last_error: Optional[Exception] = None
     attempt = 0
+    last = ""
+    body = build_pod_body(cfg, script)
     while True:
         attempt += 1
-        for gpu in cfg.gpus:
-            log(f"Requesting pod on GPU '{gpu}' ({cfg.cloud_type})...")
-            try:
-                pod = _try_create_pod(runpod, cfg, gpu)
-                if pod:
-                    log(f"Pod created: {pod['id']}")
-                    return pod
-                last_error = RuntimeError(f"Empty response creating pod on '{gpu}'.")
-            except Exception as exc:  # SDK raises various errors on no-capacity
-                log(f"Could not create pod on '{gpu}': {exc}")
-                last_error = exc
-
+        log(f"Requesting pod on {cfg.gpus} ({cfg.cloud_type})...")
+        status, resp = rest_call("POST", "/pods", cfg.api_key, body)
+        if status in (200, 201) and isinstance(resp, dict) and resp.get("id"):
+            pod_id = resp["id"]
+            log(f"Pod created: {pod_id}")
+            return pod_id
+        last = resp if isinstance(resp, str) else json.dumps(resp)
+        log(f"Create failed (status {status}): {last[:200]}")
         if time.time() >= deadline:
             break
         backoff = min(30, 5 * attempt)
         remaining = int(deadline - time.time())
-        log(f"No capacity yet; retrying in {backoff}s (~{remaining}s of wait budget left).")
+        log(f"Retrying in {backoff}s (~{remaining}s of wait budget left).")
         time.sleep(backoff)
-
-    hint = (
-        "No capacity for the requested GPU(s). Try: a longer --capacity-wait, "
-        "--cloud-type COMMUNITY, or a fallback list e.g. "
-        "--gpu 'NVIDIA GeForce RTX 4090,NVIDIA GeForce RTX 3090,NVIDIA RTX A5000'."
-    )
-    raise SystemExit(f"Failed to create a pod. {hint}\nLast error: {last_error}")
-
-
-def _shell_quote(value: str) -> str:
-    return "'" + value.replace("'", "'\"'\"'") + "'"
-
-
-def _ssh_base(key_path: str, connect_timeout: int = 20) -> List[str]:
-    return [
-        "ssh",
-        "-i", key_path,
-        "-o", "IdentitiesOnly=yes",
-        "-o", "StrictHostKeyChecking=no",
-        "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR",
-        "-o", "BatchMode=yes",
-        "-o", "ServerAliveInterval=30",
-        "-o", "ServerAliveCountMax=10",
-        "-o", f"ConnectTimeout={connect_timeout}",
-    ]
-
-
-def _ssh_destination(target: dict) -> List[str]:
-    """SSH argv tail for the pod's direct public TCP mapping for port 22."""
-    return ["-p", str(target["port"]), f"root@{target['ip']}"]
-
-
-def _direct_target_from_pod(runpod, pod_id: str) -> Optional[dict]:
-    """Best-effort: a direct public-IP:22 target if the pod exposes one yet."""
-    runtime = (runpod.get_pod(pod_id) or {}).get("runtime") or {}
-    for port in runtime.get("ports") or []:
-        if port.get("privatePort") == 22 and port.get("isIpPublic"):
-            return {"kind": "direct", "ip": port["ip"], "port": int(port["publicPort"])}
-    return None
-
-
-def wait_for_ssh(runpod, pod_id: str, key_path: str, timeout: int) -> dict:
-    """Wait until the pod's direct public-IP:22 route runs a command, then return it.
-
-    We use the direct TCP route (not RunPod's ssh.runpod.io proxy): the proxy is
-    interactive-only and silently ignores a command passed on the SSH line, so it
-    can't drive automation. The probe runs ``true`` over SSH, which proves both
-    auth AND command execution work, and retries through pod boot (banner resets,
-    auth-not-ready). Community-cloud pods get a public IP; secure-cloud ones often
-    don't, hence the --cloud-type COMMUNITY hint on failure."""
-    deadline = time.time() + timeout
-    saw_endpoint = False
-    while time.time() < deadline:
-        target = _direct_target_from_pod(runpod, pod_id)
-        remaining = int(deadline - time.time())
-        if not target:
-            log(f"Waiting for a public SSH endpoint... (~{remaining}s left).")
-            time.sleep(8)
-            continue
-        saw_endpoint = True
-        probe = _ssh_base(key_path, connect_timeout=15) + _ssh_destination(target) + ["true"]
-        result = subprocess.run(
-            probe, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True
-        )
-        if result.returncode == 0:
-            log(f"SSH ready via direct ({target['ip']}:{target['port']}).")
-            return target
-        err = (result.stderr or "").strip().splitlines()
-        log(
-            f"SSH not ready: {err[-1] if err else f'rc={result.returncode}'} "
-            f"(~{remaining}s left)."
-        )
-        time.sleep(8)
-
-    if saw_endpoint:
-        raise SystemExit(
-            f"Could not run a command over SSH to pod {pod_id} within {timeout}s "
-            "(endpoint existed but auth/exec kept failing)."
-        )
     raise SystemExit(
-        f"Pod {pod_id} never exposed a public SSH port within {timeout}s. "
-        "Use --cloud-type COMMUNITY (secure-cloud pods often have no public IP)."
-    )
-
-
-def run_remote(target: dict, key_path: str, script: str, timeout: int,
-               secret_env: Optional[dict] = None) -> Tuple[int, bool]:
-    """Stream the remote script's output live.
-
-    Returns (exit_code, done_marker_seen). The marker check is a guard against a
-    clean exit code that doesn't actually mean the script finished (e.g. a dropped
-    connection), so success requires BOTH a zero exit and the DONE marker.
-
-    ``secret_env`` is exported before the script over the encrypted SSH channel
-    (not via the pod's Docker env, which SSH sessions don't inherit) and is never
-    part of the printed script."""
-    prefix = "".join(
-        f"export {key}={_shell_quote(value)}\n" for key, value in (secret_env or {}).items()
-    )
-    # A login shell so PATH picks up the pip-installed console scripts.
-    remote = "bash -lc " + _shell_quote(prefix + script)
-    command = _ssh_base(key_path, connect_timeout=30) + _ssh_destination(target) + [remote]
-
-    proc = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
-    )
-    done_seen = False
-    try:
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            print(line, end="", flush=True)
-            if DONE_MARKER in line and "echo" not in line:
-                done_seen = True
-        return proc.wait(timeout=timeout), done_seen
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        raise SystemExit(f"Remote run exceeded {timeout}s; killed.")
-
-
-def check_ssh_key_usable(key_path: str) -> None:
-    """Fail early (before creating a billed pod) if the private key can't be used
-    non-interactively: it must be unencrypted, or encrypted but loaded in
-    ssh-agent. A passphrase-protected key that isn't in the agent would make every
-    SSH attempt fail with 'Permission denied' after the pod is already running."""
-    if not os.path.isfile(key_path):
-        raise SystemExit(f"SSH key not found: {key_path} (pass --ssh-key).")
-
-    # Unencrypted keys decrypt with an empty passphrase.
-    unencrypted = subprocess.run(
-        ["ssh-keygen", "-y", "-P", "", "-f", key_path],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
-    if unencrypted.returncode == 0:
-        return
-
-    # Encrypted: it must be present in ssh-agent (match by fingerprint).
-    fp = subprocess.run(
-        ["ssh-keygen", "-lf", key_path], capture_output=True, text=True
-    )
-    fingerprint = fp.stdout.split()[1] if fp.returncode == 0 and len(fp.stdout.split()) > 1 else ""
-    agent = subprocess.run(["ssh-add", "-l"], capture_output=True, text=True)
-    if fingerprint and fingerprint in agent.stdout:
-        return
-
-    raise SystemExit(
-        f"SSH key '{key_path}' is passphrase-protected and not loaded in ssh-agent, "
-        "so it can't authenticate non-interactively. Load it once with:\n"
-        f"    ssh-add {key_path}\n"
-        "then re-run. (Or use an unencrypted key dedicated to RunPod.)"
+        "Failed to create a pod. Try a longer --capacity-wait, a comma-separated "
+        "--gpu fallback list, or --cloud-type COMMUNITY.\nLast error: " + last
     )
 
 
@@ -360,9 +332,6 @@ def check_ssh_key_usable(key_path: str) -> None:
 # CLI
 # --------------------------------------------------------------------------- #
 def _prompt_secret(label: str) -> str:
-    """Ask the user to paste a secret (hidden input). Returns "" when there is no
-    interactive terminal, so automated/CI runs fall back to a clear error instead
-    of hanging on input."""
     import getpass
 
     if not sys.stdin.isatty():
@@ -373,112 +342,100 @@ def _prompt_secret(label: str) -> str:
         return ""
 
 
-def _read_public_key(private_key_path: str) -> str:
-    pub_path = private_key_path + ".pub"
-    if not os.path.isfile(pub_path):
-        raise SystemExit(
-            f"Public key not found at {pub_path}. Generate one with "
-            f"'ssh-keygen -t ed25519' or pass --ssh-key."
-        )
-    with open(pub_path, "r", encoding="utf-8") as handle:
-        return handle.read().strip()
-
-
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Experimental: run a SAIB benchmark on a throwaway RunPod GPU pod."
+        description="Experimental: run a SAIB benchmark on a self-terminating RunPod GPU pod (no SSH)."
     )
     parser.add_argument("--api-key", default=os.environ.get("RUNPOD_API_KEY"))
     parser.add_argument("--db-token", default=os.environ.get("AI_BENCHMARK_DATABASE_TOKEN"))
     parser.add_argument(
         "--gpu",
-        default=DEFAULT_GPUS,
-        help="GPU type id, or a comma-separated fallback list (tried in order).",
+        default="NVIDIA GeForce RTX 4090",
+        help="RunPod gpuTypeId, or a comma-separated fallback list (RunPod picks by availability).",
     )
-    parser.add_argument("--image", default=DEFAULT_IMAGE)
-    parser.add_argument("--workload", choices=sorted(WORKLOADS), default="pt")
     parser.add_argument(
-        "--pip-spec",
-        default=DEFAULT_PIP_SPEC,
-        help="pip requirement installed on the pod (point at a fork/branch here).",
+        "--workload", choices=["pt", "llm", "both"], default="both",
+        help="Which benchmark(s) to run on the pod (default: both).",
+    )
+    parser.add_argument(
+        "--image", default=None,
+        help="Container image. Default: auto by GPU generation (torch 2.4, or torch 2.8 for Blackwell).",
+    )
+    parser.add_argument(
+        "--pip-spec", default=None,
+        help="pip requirement installed on the pod. Default: auto ([pt], or [pt,lowbit] for Blackwell).",
+    )
+    parser.add_argument("--pt-args", default="", help="Extra args for saib-pt, e.g. '-w 0'.")
+    parser.add_argument(
+        "--llm-args", default=None,
+        help="Extra args for saib-llm, e.g. '-w 0 1 2'. Default: auto by lowbit capability.",
     )
     parser.add_argument("--database-url", default=DEFAULT_DATABASE_URL)
+    parser.add_argument("--disk-gb", type=int, default=40)
+    parser.add_argument("--cloud-type", choices=["SECURE", "COMMUNITY"], default="SECURE")
     parser.add_argument(
-        "--ssh-key",
-        default=os.path.expanduser("~/.ssh/id_ed25519"),
-        help="Private key path; the matching .pub is sent to the pod.",
+        "--capacity-wait", type=int, default=0,
+        help="Seconds to keep retrying while RunPod has no capacity (with backoff). 0 = try once.",
     )
-    parser.add_argument("--disk-gb", type=int, default=30)
-    parser.add_argument(
-        "--cloud-type", choices=["ALL", "SECURE", "COMMUNITY"], default="ALL"
-    )
-    parser.add_argument(
-        "--capacity-wait",
-        type=int,
-        default=0,
-        help="Seconds to keep retrying the requested GPU(s) while there is no "
-        "capacity (with backoff). 0 = try each GPU once and exit.",
-    )
-    parser.add_argument(
-        "--extra-args", default="", help="Extra args passed to the run command (e.g. '-w 0')."
-    )
+    parser.add_argument("--pt-timeout", type=int, default=3600, help="Per-step cap (s) for saib-pt.")
+    parser.add_argument("--llm-timeout", type=int, default=5400, help="Per-step cap (s) for saib-llm.")
     parser.add_argument("--no-publish", action="store_true", help="Run but do not upload results.")
     parser.add_argument(
-        "--keep", action="store_true", help="Do not terminate the pod (for debugging)."
+        "--keep", action="store_true",
+        help="Do not self-terminate the pod (debugging). You must terminate it yourself!",
     )
-    parser.add_argument("--create-timeout", type=int, default=300)
-    parser.add_argument("--ssh-timeout", type=int, default=300)
-    parser.add_argument("--run-timeout", type=int, default=3600)
     parser.add_argument(
-        "--dry-run", action="store_true", help="Print the plan and remote script, then exit."
+        "--dry-run", action="store_true",
+        help="Print the plan and container script, then exit (no API key needed).",
     )
     return parser.parse_args(argv)
 
 
 def build_config(args: argparse.Namespace) -> Config:
     gpus = [g.strip() for g in args.gpu.split(",") if g.strip()]
-    public_key = "" if args.dry_run else _read_public_key(args.ssh_key)
-    return Config(
+    cfg = Config(
         api_key=args.api_key,
         db_token=args.db_token,
         gpus=gpus,
-        image=args.image,
+        image=args.image or DEFAULT_IMAGE,
+        pip_spec=args.pip_spec or PIP_BASE,
         workload=args.workload,
-        pip_spec=args.pip_spec,
+        pt_args=args.pt_args,
+        llm_args=args.llm_args or "",
         database_url=args.database_url,
-        private_key_path=args.ssh_key,
-        public_key=public_key,
         disk_gb=args.disk_gb,
         cloud_type=args.cloud_type,
-        extra_args=args.extra_args,
         publish=not args.no_publish,
         keep=args.keep,
         capacity_wait=args.capacity_wait,
-        create_timeout=args.create_timeout,
-        ssh_timeout=args.ssh_timeout,
-        run_timeout=args.run_timeout,
+        pt_timeout=args.pt_timeout,
+        llm_timeout=args.llm_timeout,
+        image_was_set=args.image is not None,
+        pip_was_set=args.pip_spec is not None,
+        llm_args_was_set=args.llm_args is not None,
     )
+    resolve_profile(cfg)
+    return cfg
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv)
     cfg = build_config(args)
-    script = build_remote_script(cfg)
+    script = build_container_script(cfg)
 
     if args.dry_run:
         log(f"Workload: {cfg.workload}  GPUs: {cfg.gpus}  image: {cfg.image}")
-        log(f"Publish: {cfg.publish}  database: {cfg.database_url}")
-        print("\n--- remote script ---")
+        log(f"pip-spec: {cfg.pip_spec}")
+        log(f"pt-args: '{cfg.pt_args}'  llm-args: '{cfg.llm_args}'  publish: {cfg.publish}")
+        print("\n--- container script (dockerStartCmd: bash -lc) ---")
         print(script)
-        print("--- end remote script ---")
+        print("--- end container script ---")
         return 0
 
     if not cfg.api_key:
         cfg.api_key = _prompt_secret("Paste your RunPod API key (RUNPOD_API_KEY)")
     if not cfg.api_key:
-        raise SystemExit(
-            "RUNPOD_API_KEY is required (env, --api-key, or interactive prompt)."
-        )
+        raise SystemExit("RUNPOD_API_KEY is required (env, --api-key, or interactive prompt).")
     if cfg.publish and not cfg.db_token:
         cfg.db_token = _prompt_secret(
             "Paste your AI Benchmark Database token (AI_BENCHMARK_DATABASE_TOKEN)"
@@ -489,68 +446,16 @@ def main(argv: Optional[List[str]] = None) -> int:
             "(env, --db-token, interactive prompt, or pass --no-publish)."
         )
 
-    # Verify the SSH key works non-interactively before paying for a pod.
-    check_ssh_key_usable(cfg.private_key_path)
-
-    runpod = _import_runpod()
-    runpod.api_key = cfg.api_key
-
-    pod_id: Optional[str] = None
-    terminated = {"done": False}
-
-    def terminate() -> None:
-        if terminated["done"] or pod_id is None:
-            return
-        if cfg.keep:
-            log(f"--keep set; leaving pod {pod_id} running. Terminate it yourself!")
-            terminated["done"] = True
-            return
-        try:
-            log(f"Terminating pod {pod_id}...")
-            runpod.terminate_pod(pod_id)
-            log("Pod terminated.")
-        except Exception as exc:
-            log(f"WARNING: failed to terminate pod {pod_id}: {exc}. Check the RunPod console!")
-        finally:
-            terminated["done"] = True
-
-    def handle_signal(signum, _frame):
-        log(f"Received signal {signum}; cleaning up.")
-        terminate()
-        raise SystemExit(130)
-
-    signal.signal(signal.SIGINT, handle_signal)
-    signal.signal(signal.SIGTERM, handle_signal)
-
-    try:
-        pod = create_pod_with_fallback(runpod, cfg)
-        pod_id = pod["id"]
-        target = wait_for_ssh(runpod, pod_id, cfg.private_key_path, cfg.ssh_timeout)
-
-        log("Running remote benchmark (live output follows)...")
-        secret_env = (
-            {"AI_BENCHMARK_DATABASE_TOKEN": cfg.db_token}
-            if cfg.publish and cfg.db_token
-            else None
-        )
-        exit_code, done = run_remote(
-            target, cfg.private_key_path, script, cfg.run_timeout, secret_env
-        )
-
-        if exit_code == 0 and done:
-            log("Remote benchmark finished successfully.")
-            return 0
-        if exit_code == 0 and not done:
-            log(
-                "Remote benchmark did NOT complete: connection returned success but "
-                f"the '{DONE_MARKER}' marker was never seen (the remote script did "
-                "not finish). Treating as failure."
-            )
-            return 1
-        log(f"Remote benchmark FAILED with exit code {exit_code}.")
-        return exit_code
-    finally:
-        terminate()
+    # The token lives in the pod env, so rebuild the body now that it is resolved.
+    script = build_container_script(cfg)
+    pod_id = create_pod_with_retry(cfg, script)
+    log(
+        f"Pod {pod_id} is installing SAIB and will run {cfg.workload}, "
+        + ("publish, " if cfg.publish else "")
+        + ("then self-terminate." if not cfg.keep else "and stay up (--keep).")
+    )
+    log("Fire-and-forget: nothing connects back to the pod. Monitor it in the RunPod console.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -1,8 +1,14 @@
 import simple_ai_benchmarking.experimental.runpod_runner as runner
 from simple_ai_benchmarking.experimental.runpod_runner import (
+    BLACKWELL_IMAGE,
+    DEFAULT_IMAGE,
     DONE_MARKER,
+    PIP_BASE,
+    PIP_LOWBIT,
     build_config,
-    build_remote_script,
+    build_container_script,
+    build_pod_body,
+    is_blackwell,
     main,
     parse_args,
 )
@@ -12,123 +18,160 @@ def _config(argv):
     return build_config(parse_args(argv))
 
 
-def test_remote_script_cv_publish_includes_register_then_publish():
-    cfg = _config(["--dry-run", "--workload", "pt"])
-    script = build_remote_script(cfg)
+# --------------------------------------------------------------------------- #
+# Generation-aware profile resolution
+# --------------------------------------------------------------------------- #
+def test_blackwell_detection():
+    assert is_blackwell("NVIDIA B200")
+    assert is_blackwell("NVIDIA GeForce RTX 5090")
+    assert is_blackwell("NVIDIA RTX PRO 6000 Blackwell Server Edition")
+    assert not is_blackwell("NVIDIA H100 80GB HBM3")
+    assert not is_blackwell("NVIDIA RTX A6000")
+    assert not is_blackwell("NVIDIA GeForce RTX 4090")
 
-    assert "saib-pt" in script
-    # Register must come before publish so unknown-profile rejections are avoided.
-    assert script.index("saib-register results_pt.csv") < script.index(
-        "saib-pub results_pt.csv"
+
+def test_blackwell_gpu_auto_selects_torch28_image_and_lowbit():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200"])
+    assert cfg.image == BLACKWELL_IMAGE
+    assert cfg.pip_spec == PIP_LOWBIT
+    # Blackwell runs the full LLM set incl FP8 (3) and FP4 (4).
+    assert cfg.llm_args == "-w 0 1 2 3 4"
+
+
+def test_non_blackwell_gpu_auto_selects_default_image_no_lowbit():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000"])
+    assert cfg.image == DEFAULT_IMAGE
+    assert cfg.pip_spec == PIP_BASE
+    # No lowbit -> FP8/FP4 are skipped.
+    assert cfg.llm_args == "-w 0 1 2"
+
+
+def test_explicit_overrides_win_over_auto():
+    cfg = _config(
+        ["--dry-run", "--gpu", "NVIDIA H100 80GB HBM3",
+         "--image", BLACKWELL_IMAGE, "--pip-spec", PIP_LOWBIT, "--llm-args", "-w 0 1 2 3"]
     )
+    assert cfg.image == BLACKWELL_IMAGE
+    assert cfg.pip_spec == PIP_LOWBIT
+    assert cfg.llm_args == "-w 0 1 2 3"  # FP8 but no FP4 on Hopper
+
+
+def test_first_gpu_in_fallback_list_drives_the_profile():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200, NVIDIA H100 80GB HBM3"])
+    assert cfg.gpus == ["NVIDIA B200", "NVIDIA H100 80GB HBM3"]
+    assert cfg.image == BLACKWELL_IMAGE
+
+
+# --------------------------------------------------------------------------- #
+# Container script
+# --------------------------------------------------------------------------- #
+def test_script_both_runs_pt_then_llm_and_publishes():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000", "--workload", "both"])
+    script = build_container_script(cfg)
+    assert script.index("saib-pt") < script.index("saib-llm")
+    # Register must precede publish so unknown-profile rejections are avoided.
+    assert script.index("saib-register results_pt.csv") < script.index("saib-pub results_pt.csv")
+    assert script.index("saib-register llm_results.csv") < script.index("saib-pub-llm llm_results.csv")
     assert script.strip().splitlines()[-1] == f'echo "{DONE_MARKER}"'
 
 
-def test_remote_script_no_publish_skips_upload():
-    cfg = _config(["--dry-run", "--workload", "llm", "--no-publish"])
-    script = build_remote_script(cfg)
+def test_script_self_terminates_and_caps_threads_by_default():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000"])
+    script = build_container_script(cfg)
+    assert "trap cleanup EXIT" in script
+    assert "RUNPOD_POD_ID" in script  # the DELETE teardown
+    assert "OMP_NUM_THREADS=8" in script
+    assert "timeout -k 60" in script
 
+
+def test_keep_disables_self_terminate():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000", "--keep"])
+    script = build_container_script(cfg)
+    assert "trap cleanup EXIT" not in script
+    assert "will NOT self-terminate" in script
+
+
+def test_workload_llm_only_skips_pt():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000", "--workload", "llm"])
+    script = build_container_script(cfg)
     assert "saib-llm" in script
+    assert "saib-pt" not in script
+
+
+def test_no_publish_skips_upload():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000", "--no-publish"])
+    script = build_container_script(cfg)
+    assert "saib-pt" in script
     assert "saib-pub" not in script
     assert "saib-register" not in script
 
 
-def test_remote_script_never_contains_the_token():
-    # The token is injected over SSH at run time, not baked into the script.
-    cfg = _config(["--dry-run", "--workload", "pt", "--db-token", "supersecret"])
-    assert "supersecret" not in build_remote_script(cfg)
+def test_script_never_contains_the_token():
+    # The token is injected via the pod env, not baked into the script text.
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000", "--db-token", "supersecret"])
+    assert "supersecret" not in build_container_script(cfg)
 
 
-def test_gpu_fallback_list_is_parsed_in_order():
-    cfg = _config(["--dry-run", "--gpu", "A100,RTX 4090 , L40S"])
-    assert cfg.gpus == ["A100", "RTX 4090", "L40S"]
+# --------------------------------------------------------------------------- #
+# Pod body
+# --------------------------------------------------------------------------- #
+def test_pod_body_no_public_ip_and_token_in_env():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--db-token", "tok"])
+    cfg.api_key = "key"
+    body = build_pod_body(cfg, "echo hi")
+    assert body["supportPublicIp"] is False  # no SSH route needed
+    assert body["dockerStartCmd"][:2] == ["bash", "-lc"]
+    assert body["gpuTypeIds"] == ["NVIDIA B200"]
+    assert body["env"]["AI_BENCHMARK_DATABASE_TOKEN"] == "tok"
 
 
+def test_pod_body_no_publish_omits_token():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--no-publish", "--db-token", "tok"])
+    cfg.api_key = "key"
+    body = build_pod_body(cfg, "echo hi")
+    assert "AI_BENCHMARK_DATABASE_TOKEN" not in body["env"]
+
+
+# --------------------------------------------------------------------------- #
+# Capacity retry
+# --------------------------------------------------------------------------- #
 def test_dry_run_exits_zero_without_api_key(capsys):
-    assert main(["--dry-run"]) == 0
+    assert main(["--dry-run", "--gpu", "NVIDIA B200"]) == 0
     out = capsys.readouterr().out
-    assert "remote script" in out
-
-
-class _FakeRunpod:
-    def __init__(self, fail_times):
-        self.calls = 0
-        self.fail_times = fail_times
-
-    def create_pod(self, **kwargs):
-        self.calls += 1
-        if self.calls <= self.fail_times:
-            raise RuntimeError("This machine does not have the resources")
-        return {"id": "pod-123"}
+    assert "container script" in out
 
 
 def test_capacity_retry_eventually_succeeds(monkeypatch):
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
-    cfg = _config(["--dry-run", "--capacity-wait", "60"])
-    fake = _FakeRunpod(fail_times=2)
+    calls = {"n": 0}
 
-    pod = runner.create_pod_with_fallback(fake, cfg)
+    def fake_rest(method, path, key, body=None):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return 500, "This machine does not have the resources"
+        return 201, {"id": "pod-123"}
 
-    assert pod["id"] == "pod-123"
-    assert fake.calls == 3
+    monkeypatch.setattr(runner, "rest_call", fake_rest)
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--capacity-wait", "60"])
+    cfg.api_key = "key"
+    assert runner.create_pod_with_retry(cfg, "echo hi") == "pod-123"
+    assert calls["n"] == 3
 
 
 def test_no_capacity_wait_tries_once_then_exits(monkeypatch):
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
-    cfg = _config(["--dry-run", "--gpu", "A,B"])  # capacity_wait defaults to 0
-    fake = _FakeRunpod(fail_times=99)
 
+    def fake_rest(method, path, key, body=None):
+        return 500, "This machine does not have the resources"
+
+    monkeypatch.setattr(runner, "rest_call", fake_rest)
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200"])  # capacity_wait defaults to 0
+    cfg.api_key = "key"
     try:
-        runner.create_pod_with_fallback(fake, cfg)
+        runner.create_pod_with_retry(cfg, "echo hi")
         assert False, "expected SystemExit"
     except SystemExit:
         pass
-
-    # One pass over both GPUs, no retry loop.
-    assert fake.calls == 2
-
-
-def test_ssh_destination_direct_uses_root_and_port():
-    direct = runner._ssh_destination({"kind": "direct", "ip": "1.2.3.4", "port": 16593})
-    assert direct == ["-p", "16593", "root@1.2.3.4"]
-
-
-def test_ssh_base_pins_identity_and_batch_mode():
-    base = runner._ssh_base("/key")
-    assert "BatchMode=yes" in base
-    assert "IdentitiesOnly=yes" in base
-    assert base[:3] == ["ssh", "-i", "/key"]
-
-
-def test_check_ssh_key_usable_missing_file(tmp_path):
-    import pytest
-
-    with pytest.raises(SystemExit, match="not found"):
-        runner.check_ssh_key_usable(str(tmp_path / "nope"))
-
-
-def test_check_ssh_key_usable_unencrypted_passes(tmp_path):
-    key = tmp_path / "k"
-    import subprocess
-
-    subprocess.run(
-        ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key)],
-        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
-    runner.check_ssh_key_usable(str(key))  # should not raise
-
-
-def test_check_ssh_key_usable_encrypted_not_in_agent_errors(tmp_path):
-    import pytest
-    import subprocess
-
-    key = tmp_path / "enc"
-    subprocess.run(
-        ["ssh-keygen", "-t", "ed25519", "-N", "secretpass", "-f", str(key)],
-        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
-    with pytest.raises(SystemExit, match="ssh-add"):
-        runner.check_ssh_key_usable(str(key))
 
 
 def test_prompt_secret_returns_pasted_value(monkeypatch):
@@ -139,7 +182,6 @@ def test_prompt_secret_returns_pasted_value(monkeypatch):
 
 def test_prompt_secret_is_noop_without_tty(monkeypatch):
     monkeypatch.setattr(runner.sys.stdin, "isatty", lambda: False)
-    # Must not call getpass (would hang in CI); returns "" so the caller errors.
     monkeypatch.setattr(
         "getpass.getpass",
         lambda prompt="": (_ for _ in ()).throw(AssertionError("getpass called")),

--- a/tools/run_fleet.sh
+++ b/tools/run_fleet.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fire a fleet of self-terminating RunPod benchmark pods (CV + LLM), one per GPU.
+#
+# Each pod is launched with `saib-runpod` (REST dockerStartCmd, no SSH): it installs
+# SAIB, runs the benchmarks, publishes to the database, and self-terminates -- on
+# success, crash, or a hung step. Nothing connects back, so this returns quickly and
+# you monitor the pods in the RunPod console / the benchmark database.
+#
+# "lowbit only on respective GPUs and images" is enforced here per generation:
+#   * Blackwell (B200 / RTX 5090 / RTX PRO Blackwell): torch 2.8 image + [pt,lowbit],
+#     full LLM incl FP8 + FP4              -> handled automatically by saib-runpod.
+#   * Hopper / Ada (H100 / RTX 4090 ...): FP8 needs the torch 2.8 image too, so it is
+#     requested EXPLICITLY here (--image + --pip-spec + --llm-args "-w 0 1 2 3").
+#     This is opt-in because the torch 2.8 image needs a host driver >= 12.8; prefer
+#     SECURE (datacenter) hosts, which are current. Drop these overrides to fall back
+#     to the safe torch 2.4 image (no FP8).
+#   * Ampere & older (A6000 ...): no lowbit -> default torch 2.4 image + [pt],
+#     LLM -w 0 1 2                          -> handled automatically by saib-runpod.
+#
+# Usage:
+#   export RUNPOD_API_KEY=...
+#   export AI_BENCHMARK_DATABASE_TOKEN=...
+#   tools/run_fleet.sh                 # the default 5-GPU spread below
+#   FP8_ON_HOPPER_ADA=0 tools/run_fleet.sh   # skip the torch 2.8 FP8 opt-in
+set -euo pipefail
+
+: "${RUNPOD_API_KEY:?set RUNPOD_API_KEY}"
+: "${AI_BENCHMARK_DATABASE_TOKEN:?set AI_BENCHMARK_DATABASE_TOKEN}"
+
+RUNPOD="${RUNPOD:-saib-runpod}"
+CAP="${CAPACITY_WAIT:-180}"     # keep retrying thin-stock GPUs for a few minutes
+FP8="${FP8_ON_HOPPER_ADA:-1}"   # 1 = use torch 2.8 image to get FP8 on Hopper/Ada
+
+BW="runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404"
+LB="simple-ai-benchmarking[pt,lowbit]@git+https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
+
+fire() { echo "=== launching: $* ==="; "$RUNPOD" --capacity-wait "$CAP" "$@" || echo "WARN: launch failed for: $*"; }
+
+# --- Blackwell: image + lowbit + FP4 are auto-selected by saib-runpod ---------
+fire --gpu "NVIDIA B200"               --cloud-type SECURE
+fire --gpu "NVIDIA GeForce RTX 5090"   --cloud-type COMMUNITY
+
+# --- Hopper / Ada: FP8 opt-in (torch 2.8 image) -------------------------------
+if [ "$FP8" = "1" ]; then
+  fire --gpu "NVIDIA H100 80GB HBM3"   --cloud-type SECURE --image "$BW" --pip-spec "$LB" --llm-args "-w 0 1 2 3"
+  fire --gpu "NVIDIA GeForce RTX 4090" --cloud-type SECURE --image "$BW" --pip-spec "$LB" --llm-args "-w 0 1 2 3"
+else
+  fire --gpu "NVIDIA H100 80GB HBM3"   --cloud-type SECURE
+  fire --gpu "NVIDIA GeForce RTX 4090" --cloud-type SECURE
+fi
+
+# --- Ampere baseline: no lowbit (auto) ----------------------------------------
+fire --gpu "NVIDIA RTX A6000"          --cloud-type SECURE
+
+echo "All launch calls issued. Pods self-terminate when done; watch the RunPod console."


### PR DESCRIPTION
**Why:** The SSH-based `saib-runpod` needed a public IP (secure-cloud pods often have none), a registered SSH key + ssh-agent dance, and a local process connected for the whole run. Pushing the work into the pod's container start command removes all of that and makes the pod autonomous and self-terminating.

**What:**
- Rewrite `runpod_runner.py` to drive the run via the RunPod REST API `dockerStartCmd` (`bash -lc`): install SAIB, run `saib-pt`/`saib-llm`, register+publish over HTTPS, then self-terminate via a `trap` (`DELETE /v1/pods/$RUNPOD_POD_ID`). No SSH, no public IP, no SDK (stdlib `urllib`). Thread caps (`OMP/BLAS=8`) + per-step `timeout` guard against oversubscription and hangs.
- Auto-select image + low-bit per GPU generation: Blackwell → torch 2.8 image + `[pt,lowbit]` + FP8/FP4; everything else → torch 2.4 image + `[pt]`. Never pairs `[pt,lowbit]` with the torch 2.4 image (that aborts the whole install). FP8 on Hopper/Ada is documented opt-in.
- Add `tools/run_fleet.sh` to launch a multi-GPU spread in one command.
- Update README (rewritten RunPod section) and the now-optional `[runpod]` extra note in `setup.py`.

**Test:** `python -m pytest tests/test_runpod_runner.py` (18 passing, rewritten for the REST design) and full suite `python -m pytest` (79 passing); `python -m py_compile` on the runner and `bash -n tools/run_fleet.sh` clean. Live-validated end to end: 5 self-terminating CV+LLM pods (B200, RTX 5090, H100, RTX 4090, A6000) launched and published to the database.