### PR TITLE
feat: Add per-workload publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ If `RUNPOD_API_KEY` or `AI_BENCHMARK_DATABASE_TOKEN` are not set (and not passed
 
 | GPU generation | Image | pip extra | Default LLM `-w` | Low-bit |
 |---|---|---|---|---|
-| **Blackwell** (B200, RTX 5090, RTX PRO Blackwell) | `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` (torch 2.8 / CUDA 12.8) | `[pt,lowbit]` | `0 1 2 3 4` | **FP8 + FP4** |
+| **Blackwell** (B200, RTX 5090, RTX PRO Blackwell) | `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` (torch 2.8 / CUDA 12.8) | `[pt,lowbit]` + `torchao==0.13.0+cu128` | `0 1 2 3 4` | **FP8 + FP4** |
 | **Everything else** (Hopper, Ada, Ampere, …) | `runpod/pytorch:2.4.0-...cuda12.4.1` (torch 2.4) | `[pt]` | `0 1 2` | none |
 
 Blackwell is special-cased automatically because it *cannot* run on the torch 2.4 image at all. **FP8 on Hopper/Ada is opt-in**, not automatic: it needs the torch 2.8 image too, but that image requires a host driver ≥ 12.8 and can fail to start on older-driver non-Blackwell hosts. Enable it explicitly (prefer SECURE/datacenter hosts):
@@ -262,7 +262,7 @@ saib-runpod --gpu "NVIDIA H100 80GB HBM3" --cloud-type SECURE \
   --llm-args "-w 0 1 2 3"     # FP8 yes, FP4 no (Hopper/Ada have no FP4)
 ```
 
-> ⚠️ Never pair `[pt,lowbit]` with the torch 2.4 image — torchao is unpinned and won't resolve there, which **aborts the whole install** so nothing runs. The auto-selection above guarantees this pairing never happens; only override it knowingly.
+> ⚠️ Never pair `[pt,lowbit]` with the torch 2.4 image. The automatic RunPod profile pins the CUDA wheel `torchao==0.13.0+cu128`, the release built for its torch 2.8 image; custom image/pip overrides must select a torchao version compatible with their torch build.
 
 **GPU names** are the RunPod GPU *ids*, e.g. `NVIDIA GeForce RTX 4090`, `NVIDIA H100 80GB HBM3` (H100 SXM), `NVIDIA H200`, `NVIDIA B200` — not the short display names. List them with `python -c "import runpod,os; runpod.api_key=os.environ['RUNPOD_API_KEY']; print('\n'.join(g['id'] for g in runpod.get_gpus()))"`.
 
@@ -355,4 +355,3 @@ This project (simple-ai-benchmarking) is licensed under the GNU General Public L
 ## AI Assistance
 
 Development of this project was supported by AI agents (Claude, ChatGPT).
-

--- a/simple_ai_benchmarking/benchmark.py
+++ b/simple_ai_benchmarking/benchmark.py
@@ -17,13 +17,17 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from typing import List
+from typing import Callable, List, Optional
 from multiprocessing import Process, Queue, set_start_method
 
 from loguru import logger
 
 from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
-from simple_ai_benchmarking.results import BenchmarkLogger, BenchmarkResult
+from simple_ai_benchmarking.results import (
+    BaseBenchmarkLogger,
+    BenchmarkLogger,
+    BenchmarkResult,
+)
 from simple_ai_benchmarking.timer import Timer
 from simple_ai_benchmarking.dataset import get_available_memory_in_bytes
 
@@ -33,6 +37,7 @@ def process_workloads(
     out_file_base="benchmark_results",
     repetitions=3,
     result_logger=None,
+    on_workload_logged: Optional[Callable[[BaseBenchmarkLogger], None]] = None,
 ) -> None:
 
     assert workloads, "Got empty list fo workloads."
@@ -50,6 +55,12 @@ def process_workloads(
         result_logger.add_benchmark_result_by_averaging_multiple_results(
             benchmark_repetition_results
         )
+        result_logger.export_to_csv(out_file_base + ".csv")
+        if on_workload_logged:
+            try:
+                on_workload_logged(result_logger)
+            except Exception as e:
+                logger.warning(f"Could not publish workload result: {e}")
 
     result_logger.pretty_print_summary()
 

--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -25,6 +25,7 @@ import json
 
 import requests
 from requests.auth import HTTPBasicAuth
+from loguru import logger
 
 from dataclasses import dataclass
 
@@ -411,26 +412,40 @@ def read_and_enrich_benchmark_data(args):
     )
 
 
-def submit_results(benchmark_datasets, args, submit_url, api_token):
-    """Submit benchmark results to the database."""
+def submit_results(
+    benchmark_datasets,
+    submit_url,
+    api_token=None,
+    user=None,
+    password=None,
+) -> int:
+    """Submit benchmark results to the database and return the failure count."""
+    failures = 0
     for benchmark_data in benchmark_datasets:
         print("Publishing...")
 
-        if api_token:
-            outcome = submit_benchmark_result_token_auth(
-                benchmark_data, submit_url, api_token
-            )
-        else:
-            outcome = submit_benchmark_result_user_pw_auth(
-                benchmark_data, submit_url, args.user, args.password
-            )
+        try:
+            if api_token:
+                outcome = submit_benchmark_result_token_auth(
+                    benchmark_data, submit_url, api_token
+                )
+            else:
+                outcome = submit_benchmark_result_user_pw_auth(
+                    benchmark_data, submit_url, user, password
+                )
+        except Exception as e:
+            print(f"Submission failed: {e}")
+            failures += 1
+            break
 
         if outcome == SUBMIT_DUPLICATE:
             # Already on the server; skip this run and keep publishing the rest.
             continue
         if outcome == SUBMIT_FAILED:
             print("Submission failed. Exiting...")
+            failures += 1
             break
+    return failures
 
 
 def publish_results_cli():
@@ -444,7 +459,115 @@ def publish_results_cli():
 
     benchmark_datasets = read_and_enrich_benchmark_data(args)
 
-    submit_results(benchmark_datasets, args, submit_url, api_token)
+    submit_results(
+        benchmark_datasets,
+        submit_url,
+        api_token,
+        user=args.user,
+        password=args.password,
+    )
+
+
+def register_profiles_from_csv(
+    csv_path,
+    database_url,
+    *,
+    token=None,
+    user=None,
+    password=None,
+) -> int:
+    """Register unique profiles from a CSV and return the failure count."""
+    url = database_url.rstrip("/") + "/benchmarks/profiles/register/"
+
+    headers = {}
+    auth = None
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    elif user and password:
+        auth = HTTPBasicAuth(user, password)
+    else:
+        raise ValueError("Provide a token or user and password.")
+
+    fields = {
+        "benchmark_family": "bench_info_benchmark_family",
+        "benchmark_spec_name": "bench_info_benchmark_spec_name",
+        "benchmark_spec_version": "bench_info_benchmark_spec_version",
+        "benchmark_profile_id": "bench_info_benchmark_profile_id",
+        "benchmark_profile_hash": "bench_info_benchmark_profile_hash",
+        "benchmark_runner_id": "bench_info_benchmark_runner_id",
+        "benchmark_runner_hash": "bench_info_benchmark_runner_hash",
+    }
+
+    seen = set()
+    failures = 0
+
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            phash = row.get(fields["benchmark_profile_hash"])
+            if not phash or phash in seen:
+                continue
+            seen.add(phash)
+            payload = {k: row.get(src, "") for k, src in fields.items()}
+            try:
+                r = requests.post(
+                    url, json=payload, headers=headers, auth=auth, timeout=30
+                )
+                if r.status_code in (200, 201):
+                    print(
+                        f"[{r.status_code}] {payload['benchmark_profile_id']} "
+                        f"({phash[:12]})"
+                    )
+                else:
+                    failures += 1
+                    print(f"[{r.status_code}] FAILED {phash[:12]}: {r.text}")
+            except Exception as e:
+                failures += 1
+                print(f"FAILED {phash[:12]}: {e}")
+
+    if not seen:
+        raise ValueError("No profile hashes found in CSV.")
+    return failures
+
+
+def build_incremental_publisher(
+    *,
+    csv_path,
+    read_csv_fn,
+    submit_url,
+    database_url,
+    token,
+):
+    """Build a callback that registers profiles and publishes newly added rows."""
+    published_count = 0
+
+    def publish(result_logger=None):
+        nonlocal published_count
+        try:
+            datasets = read_csv_fn(csv_path)
+            new_datasets = datasets[published_count:]
+            if not new_datasets:
+                return
+            registration_failures = register_profiles_from_csv(
+                csv_path, database_url, token=token
+            )
+            if registration_failures:
+                raise RuntimeError(
+                    f"Failed to register {registration_failures} benchmark profile(s)."
+                )
+            submission_failures = submit_results(new_datasets, submit_url, token)
+            if submission_failures:
+                raise RuntimeError(
+                    f"Failed to submit {submission_failures} benchmark result(s)."
+                )
+            published_count = len(datasets)
+        except Exception as e:
+            logger.warning(f"Could not incrementally publish benchmark results: {e}")
+
+    return publish
 
 
 def register_profiles_cli():
@@ -471,82 +594,23 @@ def register_profiles_cli():
         "saib-pub; registration is already non-interactive when a token "
         "(-t) or AI_BENCHMARK_DATABASE_TOKEN is provided.",
     )
-    parser.add_argument(
-        "-t",
-        "--token",
-        type=str,
-        default=None,
-        help="API token to authenticate with the database.",
-    )
-    parser.add_argument(
-        "-u",
-        "--user",
-        type=str,
-        default=None,
-        help="User to authenticate with the database.",
-    )
-    parser.add_argument(
-        "-p",
-        "--password",
-        type=str,
-        default=None,
-        help="Password to authenticate with the database.",
-    )
+    parser.add_argument("-t", "--token", type=str, default=None)
+    parser.add_argument("-u", "--user", type=str, default=None)
+    parser.add_argument("-p", "--password", type=str, default=None)
     args = parser.parse_args()
 
-    url = args.database_url.rstrip("/") + "/benchmarks/profiles/register/"
-    
     api_token = handle_token_pw_user(args)
-    headers = {}
-    auth = None
-    if api_token:
-        headers["Authorization"] = f"Token {api_token}"
-    elif args.user and args.password:
-        auth = HTTPBasicAuth(args.user, args.password)
-    else:
+    try:
+        failures = register_profiles_from_csv(
+            args.results_csv_path,
+            args.database_url,
+            token=api_token,
+            user=args.user,
+            password=args.password,
+        )
+    except (FileNotFoundError, ValueError) as e:
         import sys
-        sys.exit("Provide a token or user and password.")
-
-    fields = {
-        "benchmark_family": "bench_info_benchmark_family",
-        "benchmark_spec_name": "bench_info_benchmark_spec_name",
-        "benchmark_spec_version": "bench_info_benchmark_spec_version",
-        "benchmark_profile_id": "bench_info_benchmark_profile_id",
-        "benchmark_profile_hash": "bench_info_benchmark_profile_hash",
-        "benchmark_runner_id": "bench_info_benchmark_runner_id",
-        "benchmark_runner_hash": "bench_info_benchmark_runner_hash",
-    }
-
-    seen = set()
-    failures = 0
-    
-    if not os.path.exists(args.results_csv_path):
-        import sys
-        sys.exit(f"CSV file not found: {args.results_csv_path}")
-
-    with open(args.results_csv_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            phash = row.get(fields["benchmark_profile_hash"])
-            if not phash or phash in seen:
-                continue
-            seen.add(phash)
-            payload = {k: row.get(src, "") for k, src in fields.items()}
-            try:
-                r = requests.post(url, json=payload, headers=headers, auth=auth, timeout=30)
-                if r.status_code in (200, 201):
-                    print(f"[{r.status_code}] {payload['benchmark_profile_id']} ({phash[:12]})")
-                else:
-                    failures += 1
-                    print(f"[{r.status_code}] FAILED {phash[:12]}: {r.text}")
-            except Exception as e:
-                failures += 1
-                print(f"FAILED {phash[:12]}: {e}")
-
-    if not seen:
-        import sys
-        sys.exit("No profile hashes found in CSV.")
+        sys.exit(str(e))
     if failures:
         import sys
         sys.exit(1)
-

--- a/simple_ai_benchmarking/entrypoints.py
+++ b/simple_ai_benchmarking/entrypoints.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from argparse import ArgumentParser
+import os
 from typing import List
 
 from loguru import logger
@@ -65,6 +66,22 @@ class BenchmarkDispatcher:
             default=None,
             help="Override amount of batches to process for all workloads. Default: None (no override)",
         )
+        parser.add_argument(
+            "--publish-each",
+            action="store_true",
+            help="Register and publish each workload immediately after it completes.",
+        )
+        parser.add_argument(
+            "--non-interactive",
+            action="store_true",
+            help="Run publishing without interactive metadata prompts.",
+        )
+        parser.add_argument("-t", "--token", default=None)
+        parser.add_argument(
+            "--database-url",
+            default="https://timoillusion.pythonanywhere.com",
+            help="The URL of the AI Benchmark Database.",
+        )
         return parser
 
     def _header(self):
@@ -74,20 +91,57 @@ class BenchmarkDispatcher:
     def run(self, args: List[str] = None):
         self._header()
         initialize_logger(self.LOG_FILE_PATH)
+        parsed_args = self.parser.parse_args(args)
+        publisher = self._build_publisher(parsed_args)
         workload_configs = build_default_pt_workload_configs(
             self.framework,
             batch_size=self.BATCH_SIZE,
             num_batches_inference=self.NUM_BATCHES_INFERENCE,
             num_batches_training=self.NUM_BATCHES_TRAINING,
         )
-        workload_configs = self._override_workload_cfg(workload_configs, args=args)
+        workload_configs = self._override_workload_cfg(
+            workload_configs, parsed_args=parsed_args
+        )
         workloads = WorkloadFactory.build_multiple_workloads(
             workload_configs, self.framework
         )
-        process_workloads(workloads, self.results_name, repetitions=self.REPETITIONS)
+        process_workloads(
+            workloads,
+            self.results_name,
+            repetitions=self.REPETITIONS,
+            on_workload_logged=publisher,
+        )
 
-    def _override_workload_cfg(self, workload_cfgs: List[AIWorkloadBaseConfig], args: List[str] = None):
-        parsed_args = self.parser.parse_args(args)
+    def _build_publisher(self, parsed_args):
+        if not parsed_args.publish_each:
+            return None
+        token = parsed_args.token or os.environ.get("AI_BENCHMARK_DATABASE_TOKEN")
+        if not token:
+            raise SystemExit(
+                "--publish-each requires -t/--token or "
+                "AI_BENCHMARK_DATABASE_TOKEN."
+            )
+        from simple_ai_benchmarking.database import (
+            build_incremental_publisher,
+            read_csv_and_create_benchmark_dataset,
+        )
+
+        database_url = parsed_args.database_url.rstrip("/")
+        return build_incremental_publisher(
+            csv_path=self.results_name + ".csv",
+            read_csv_fn=read_csv_and_create_benchmark_dataset,
+            submit_url=database_url + "/benchmarks/submit/",
+            database_url=database_url,
+            token=token,
+        )
+
+    def _override_workload_cfg(
+        self,
+        workload_cfgs: List[AIWorkloadBaseConfig],
+        args: List[str] = None,
+        parsed_args=None,
+    ):
+        parsed_args = parsed_args or self.parser.parse_args(args)
         workload_info = [f"[{i}] {w}" for i, w in enumerate(workload_cfgs)]
         logger.info("Available workloads:")
         for x in workload_info:

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -75,10 +75,10 @@ DEFAULT_DATABASE_URL = "https://timoillusion.pythonanywhere.com"
 DEFAULT_IMAGE = "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"
 BLACKWELL_IMAGE = "runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404"
 
-# The lowbit extra pulls in torchao for real FP8/FP4 kernels. torchao is unpinned
-# and tracks recent torch, so installing it on the torch 2.4 image FAILS and aborts
-# the whole install -- hence lowbit is only ever paired with the Blackwell (torch
-# 2.8) image here. FP8/FP4 aren't usable on the torch 2.4 generation anyway.
+# The lowbit extra pulls in torchao for real FP8/FP4 kernels. torchao tracks recent
+# torch closely, so the RunPod torch 2.8 image must use the matching torchao release.
+# Without this explicit pin, pip currently installs a newer torchao whose compiled
+# extensions require torch >= 2.11, disabling NVFP4 and hurting low-bit performance.
 PIP_BASE = (
     "simple-ai-benchmarking[pt]@git+"
     "https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
@@ -87,6 +87,8 @@ PIP_LOWBIT = (
     "simple-ai-benchmarking[pt,lowbit]@git+"
     "https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
 )
+TORCHAO_TORCH28 = "torchao==0.13.0+cu128"
+TORCHAO_CU128_INDEX = "https://download.pytorch.org/whl/cu128"
 
 # RunPod gpuTypeId substrings that identify a Blackwell card. Matched case-folded.
 BLACKWELL_MARKERS = (
@@ -207,9 +209,14 @@ trap cleanup EXIT"""
 
 def _pt_block(cfg: Config) -> str:
     args = f" {cfg.pt_args}" if cfg.pt_args else ""
+    publish_args = (
+        ' --publish-each --non-interactive --database-url "${URL}"'
+        if cfg.publish
+        else ""
+    )
     lines = [
         'echo "== [pt] running (timeout ${PT_TIMEOUT}s) =="',
-        f'timeout -k 60 "${{PT_TIMEOUT}}" saib-pt{args} || echo "WARN saib-pt rc=$?"',
+        f'timeout -k 60 "${{PT_TIMEOUT}}" saib-pt{args}{publish_args} || echo "WARN saib-pt rc=$?"',
     ]
     if cfg.publish:
         lines += [
@@ -223,9 +230,14 @@ def _pt_block(cfg: Config) -> str:
 
 def _llm_block(cfg: Config) -> str:
     args = f" {cfg.llm_args}" if cfg.llm_args else ""
+    publish_args = (
+        ' --publish-each --non-interactive --database-url "${URL}"'
+        if cfg.publish
+        else ""
+    )
     lines = [
         'echo "== [llm] running (timeout ${LLM_TIMEOUT}s) =="',
-        f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm{args} || echo "WARN saib-llm rc=$?"',
+        f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm{args}{publish_args} || echo "WARN saib-llm rc=$?"',
     ]
     if cfg.publish:
         lines += [
@@ -241,6 +253,14 @@ def build_container_script(cfg: Config) -> str:
     """The bash exec'd by the pod's dockerStartCmd. The DB token is read from the
     pod env (``AI_BENCHMARK_DATABASE_TOKEN``), never interpolated into the text, so
     it is not baked into the script string."""
+    pip_requirements = [f'"{cfg.pip_spec}"']
+    pip_index_args = ""
+    if cfg.pip_spec == PIP_LOWBIT:
+        # Resolve the project and torchao together so pip never installs an
+        # incompatible latest torchao or the Python-only PyPI wheel.
+        pip_requirements.insert(0, f'"{TORCHAO_TORCH28}"')
+        pip_index_args = f" --extra-index-url {TORCHAO_CU128_INDEX}"
+
     blocks = [
         _THREAD_CAPS,
         _SELF_TERMINATE if not cfg.keep else 'echo "== --keep: pod will NOT self-terminate =="',
@@ -249,7 +269,7 @@ def build_container_script(cfg: Config) -> str:
         f'LLM_TIMEOUT="{cfg.llm_timeout}"',
         'echo "== installing SAIB =="',
         "python -m pip install --upgrade pip",
-        f'pip install "{cfg.pip_spec}"',
+        f"pip install{pip_index_args} {' '.join(pip_requirements)}",
     ]
     if cfg.workload in ("pt", "both"):
         blocks.append(_pt_block(cfg))

--- a/simple_ai_benchmarking/llm_database.py
+++ b/simple_ai_benchmarking/llm_database.py
@@ -159,4 +159,10 @@ def publish_llm_results_cli():
 
     api_token = handle_token_pw_user(args)
     benchmark_datasets = read_and_enrich_llm_benchmark_data(args)
-    submit_results(benchmark_datasets, args, submit_url, api_token)
+    submit_results(
+        benchmark_datasets,
+        submit_url,
+        api_token,
+        user=args.user,
+        password=args.password,
+    )

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -153,6 +153,22 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--attention-heads", type=int, default=4)
     parser.add_argument("--feedforward-dim", type=int, default=1024)
     parser.add_argument("--out-file-base", default="llm_results")
+    parser.add_argument(
+        "--publish-each",
+        action="store_true",
+        help="Register and publish each workload immediately after it completes.",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Run publishing without interactive metadata prompts.",
+    )
+    parser.add_argument("-t", "--token", default=None)
+    parser.add_argument(
+        "--database-url",
+        default="https://timoillusion.pythonanywhere.com",
+        help="The URL of the AI Benchmark Database.",
+    )
     return parser.parse_args()
 
 
@@ -304,10 +320,34 @@ def build_generation_configs(args: argparse.Namespace):
     return [build_generation_config_from_args(args, backend) for backend in backends]
 
 
+def _build_incremental_publisher(args):
+    if not args.publish_each:
+        return None
+    token = args.token or os.environ.get("AI_BENCHMARK_DATABASE_TOKEN")
+    if not token:
+        raise SystemExit(
+            "--publish-each requires -t/--token or AI_BENCHMARK_DATABASE_TOKEN."
+        )
+    from simple_ai_benchmarking.database import build_incremental_publisher
+    from simple_ai_benchmarking.llm_database import (
+        read_csv_and_create_llm_benchmark_dataset,
+    )
+
+    database_url = args.database_url.rstrip("/")
+    return build_incremental_publisher(
+        csv_path=args.out_file_base + ".csv",
+        read_csv_fn=read_csv_and_create_llm_benchmark_dataset,
+        submit_url=database_url + "/benchmarks/llm/submit/",
+        database_url=database_url,
+        token=token,
+    )
+
+
 def run_llm_generation_cli() -> None:
     from loguru import logger
 
     args = parse_arguments()
+    publisher = _build_incremental_publisher(args)
     if args.backend is None:
         logger.info("Available default workloads (use -w to select a subset):")
         for i, backend in enumerate(DEFAULT_LLM_BACKENDS):
@@ -326,4 +366,5 @@ def run_llm_generation_cli() -> None:
         out_file_base=args.out_file_base,
         repetitions=args.repetitions,
         result_logger=LLMBenchmarkLogger(),
+        on_workload_logged=publisher,
     )

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.11.0"
+VERSION = "0.12.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -344,9 +344,15 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
             try:
                 # torchao >= 0.x Config-class API.
                 from torchao.quantization import (
-                    Float8DynamicActivationFloat8WeightConfig as fp8_config,
+                    Float8DynamicActivationFloat8WeightConfig,
                     Int4WeightOnlyConfig as int4_config,
                     Int8WeightOnlyConfig as int8_config,
+                    PerRow,
+                )
+                # Per-row is torchao's recommended FP8 inference recipe and the
+                # recipe used for its published LLM inference benchmarks.
+                fp8_config = Float8DynamicActivationFloat8WeightConfig(
+                    granularity=PerRow()
                 )
             except ImportError:
                 # Older function-style API.
@@ -363,7 +369,9 @@ class _DtypeQuantGeneration(PyTorchLocalGeneration):
                 "FP32/FP16/BF16 work without it."
             ) from exc
         if precision == "FP8":
-            quantize_(model, fp8_config())
+            if callable(fp8_config):
+                fp8_config = fp8_config()
+            quantize_(model, fp8_config)
         elif precision == "FP4":
             # NVFP4 is a torchao prototype and needs an NVIDIA Blackwell (SM100)
             # GPU; a missing/older torchao surfaces as the same NotImplementedError.

--- a/tests/test_benchmark_dispatcher.py
+++ b/tests/test_benchmark_dispatcher.py
@@ -45,7 +45,37 @@ def test_tf_benchmark() -> None:
     _make_fast_dispatcher(AIFramework.TENSORFLOW).run(args=_FAST_ARGS)
 
 
+def test_publish_each_requires_token(monkeypatch):
+    monkeypatch.delenv("AI_BENCHMARK_DATABASE_TOKEN", raising=False)
+    dispatcher = BenchmarkDispatcher(AIFramework.PYTORCH)
+    args = dispatcher.parser.parse_args(["--publish-each"])
+
+    import pytest
+
+    with pytest.raises(SystemExit, match="requires"):
+        dispatcher._build_publisher(args)
+
+
+def test_dispatcher_wires_incremental_publisher(monkeypatch):
+    import simple_ai_benchmarking.entrypoints as entrypoints
+
+    publisher = object()
+    captured = {}
+    monkeypatch.setattr(entrypoints, "initialize_logger", lambda path: None)
+    monkeypatch.setattr(entrypoints, "build_default_pt_workload_configs", lambda *a, **k: [])
+    monkeypatch.setattr(
+        entrypoints.WorkloadFactory, "build_multiple_workloads", lambda *a, **k: ["workload"]
+    )
+    monkeypatch.setattr(
+        entrypoints, "process_workloads", lambda *a, **k: captured.update(k)
+    )
+    monkeypatch.setattr(BenchmarkDispatcher, "_build_publisher", lambda self, args: publisher)
+
+    BenchmarkDispatcher(AIFramework.PYTORCH).run(args=["--publish-each", "-t", "tok"])
+
+    assert captured["on_workload_logged"] is publisher
+
+
 if __name__ == "__main__":
     test_pt_benchmark()
     test_tf_benchmark()
-

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,6 +1,7 @@
 import queue as queue_mod
+from types import SimpleNamespace
 
-from simple_ai_benchmarking.benchmark import _extract_repetition_result
+from simple_ai_benchmarking.benchmark import _extract_repetition_result, process_workloads
 from simple_ai_benchmarking.workloads.ai_workload import AIWorkload
 from simple_ai_benchmarking.workloads.llm_workload import PyTorchLocalGeneration
 
@@ -51,3 +52,64 @@ def test_llm_workload_unifies_on_public_sync_device():
     # so the generic benchmark loop and the internal timing share one mechanism.
     assert PyTorchLocalGeneration.sync_device is not AIWorkload.sync_device
     assert not hasattr(PyTorchLocalGeneration, "_sync_device")
+
+
+class _Logger:
+    def __init__(self):
+        self.results = []
+        self.exported_sizes = []
+        self.excel_exported = False
+
+    def add_benchmark_result_by_averaging_multiple_results(self, results):
+        self.results.append(results[0])
+
+    def export_to_csv(self, path):
+        self.exported_sizes.append(len(self.results))
+
+    def export_to_excel(self, path):
+        self.excel_exported = True
+
+    def pretty_print_summary(self):
+        pass
+
+
+def test_process_workloads_exports_and_calls_back_after_each_workload(monkeypatch):
+    result_logger = _Logger()
+    callback_sizes = []
+    monkeypatch.setattr(
+        "simple_ai_benchmarking.benchmark._repeat_benchmark_n_times",
+        lambda workload, repetitions: [SimpleNamespace(workload=workload)],
+    )
+
+    process_workloads(
+        ["a", "b"],
+        result_logger=result_logger,
+        on_workload_logged=lambda logger: callback_sizes.append(len(logger.results)),
+    )
+
+    assert callback_sizes == [1, 2]
+    assert result_logger.exported_sizes == [1, 2, 2]
+    assert result_logger.excel_exported
+
+
+def test_process_workloads_swallowing_callback_failure_keeps_running(monkeypatch):
+    result_logger = _Logger()
+    callback_calls = []
+    monkeypatch.setattr(
+        "simple_ai_benchmarking.benchmark._repeat_benchmark_n_times",
+        lambda workload, repetitions: [SimpleNamespace(workload=workload)],
+    )
+
+    def failing_callback(logger):
+        callback_calls.append(len(logger.results))
+        raise RuntimeError("publish unavailable")
+
+    process_workloads(
+        ["a", "b"],
+        result_logger=result_logger,
+        on_workload_logged=failing_callback,
+    )
+
+    assert callback_calls == [1, 2]
+    assert result_logger.exported_sizes == [1, 2, 2]
+    assert result_logger.excel_exported

--- a/tests/test_kv_decoder.py
+++ b/tests/test_kv_decoder.py
@@ -1,4 +1,5 @@
 import sys
+import types
 
 import pytest
 
@@ -269,6 +270,47 @@ def test_hf_fp8_low_bit_backend_identity_and_requires_torchao(monkeypatch):
     _skip_if_torchao_available()
     with pytest.raises(NotImplementedError):
         workload.setup()
+
+
+def test_fp8_uses_recommended_per_row_torchao_recipe(monkeypatch):
+    seen = {}
+
+    class PerRow:
+        pass
+
+    class Float8Config:
+        def __init__(self, *, granularity):
+            self.granularity = granularity
+
+    quantization = types.ModuleType("torchao.quantization")
+    quantization.Float8DynamicActivationFloat8WeightConfig = Float8Config
+    quantization.Int4WeightOnlyConfig = type("Int4Config", (), {})
+    quantization.Int8WeightOnlyConfig = type("Int8Config", (), {})
+    quantization.PerRow = PerRow
+
+    def quantize_(model, config):
+        seen["model"] = model
+        seen["config"] = config
+
+    quantization.quantize_ = quantize_
+    torchao = types.ModuleType("torchao")
+    torchao.quantization = quantization
+    monkeypatch.setitem(sys.modules, "torchao", torchao)
+    monkeypatch.setitem(sys.modules, "torchao.quantization", quantization)
+
+    workload = HuggingFaceCausalFP8Generation(
+        LLMGenerationConfig(
+            backend=HF_CAUSAL_FP8_BACKEND,
+            model="dummy/model",
+            compute_precision="FP8",
+        )
+    )
+    model = object()
+
+    assert workload._apply_precision_quant(model) is model
+    assert seen["model"] is model
+    assert isinstance(seen["config"], Float8Config)
+    assert isinstance(seen["config"].granularity, PerRow)
 
 
 def test_hf_fp4_low_bit_backend_identity_and_requires_torchao(monkeypatch):

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -183,3 +183,39 @@ def test_build_generation_config_pytorch_metadata_defaults():
     assert config.accelerator == "CPU"
     assert config.base_url == ""
     assert config.model_cfg.vocab_size == 128
+
+
+def test_llm_publish_each_requires_token(monkeypatch):
+    import pytest
+    import simple_ai_benchmarking.llm_generation as llm_generation
+
+    monkeypatch.delenv("AI_BENCHMARK_DATABASE_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["saib-llm", "--backend", OLLAMA_BACKEND, "--publish-each"],
+    )
+    monkeypatch.setattr(llm_generation, "build_generation_configs", lambda args: [])
+
+    with pytest.raises(SystemExit, match="requires"):
+        llm_generation.run_llm_generation_cli()
+
+
+def test_llm_publish_each_wires_incremental_publisher(monkeypatch):
+    import simple_ai_benchmarking.database as database
+    import simple_ai_benchmarking.llm_generation as llm_generation
+
+    publisher = object()
+    captured = {}
+    monkeypatch.setattr(
+        "sys.argv",
+        ["saib-llm", "--backend", OLLAMA_BACKEND, "--publish-each", "-t", "tok"],
+    )
+    monkeypatch.setattr(llm_generation, "build_generation_configs", lambda args: [])
+    monkeypatch.setattr(database, "build_incremental_publisher", lambda **kwargs: publisher)
+    monkeypatch.setattr(
+        llm_generation, "process_workloads", lambda *args, **kwargs: captured.update(kwargs)
+    )
+
+    llm_generation.run_llm_generation_cli()
+
+    assert captured["on_workload_logged"] is publisher

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -22,10 +22,12 @@ from dataclasses import dataclass
 from tempfile import NamedTemporaryFile
 
 from simple_ai_benchmarking.database import (
+    build_incremental_publisher,
     build_publish_parser,
     enrich_benchmark_data,
     get_git_commit_hash_from_package_version,
     read_csv_and_create_benchmark_dataset,
+    register_profiles_from_csv,
 )
 from simple_ai_benchmarking.llm_database import read_csv_and_create_llm_benchmark_dataset
 
@@ -175,6 +177,60 @@ class TestPublishDatabase(unittest.TestCase):
         finally:
             os.remove(csv_path)
 
+    def test_register_profiles_from_csv_deduplicates_profiles(self):
+        from unittest.mock import MagicMock, patch
+
+        csv_path = _write_csv(
+            "bench_info_benchmark_family,bench_info_benchmark_spec_name,"
+            "bench_info_benchmark_spec_version,bench_info_benchmark_profile_id,"
+            "bench_info_benchmark_profile_hash,bench_info_benchmark_runner_id,"
+            "bench_info_benchmark_runner_hash\n"
+            "cv,spec,1,p1,hash1,r1,rhash\n"
+            "cv,spec,1,p1,hash1,r1,rhash\n"
+            "cv,spec,1,p2,hash2,r1,rhash\n"
+        )
+        response = MagicMock(status_code=201)
+        try:
+            with patch("simple_ai_benchmarking.database.requests.post", return_value=response) as post:
+                failures = register_profiles_from_csv(
+                    csv_path, "http://database.test/", token="tok"
+                )
+        finally:
+            os.remove(csv_path)
+
+        self.assertEqual(failures, 0)
+        self.assertEqual(post.call_count, 2)
+
+    def test_incremental_publisher_submits_only_new_tail_and_retries_failures(self):
+        from unittest.mock import patch
+        from simple_ai_benchmarking import database as db
+
+        rows = ["a"]
+        submitted = []
+        outcomes = iter([1, 0, 0])
+
+        def submit(datasets, submit_url, token):
+            submitted.append(list(datasets))
+            return next(outcomes)
+
+        publisher = build_incremental_publisher(
+            csv_path="results.csv",
+            read_csv_fn=lambda path: list(rows),
+            submit_url="http://database.test/benchmarks/submit/",
+            database_url="http://database.test",
+            token="tok",
+        )
+        with patch.object(db, "register_profiles_from_csv", return_value=0), patch.object(
+            db, "submit_results", side_effect=submit
+        ):
+            publisher()
+            rows.append("b")
+            publisher()
+            rows.append("c")
+            publisher()
+
+        self.assertEqual(submitted, [["a"], ["a", "b"], ["c"]])
+
 
 class TestSubmissionOutcomes(unittest.TestCase):
 
@@ -214,7 +270,6 @@ class TestSubmissionOutcomes(unittest.TestCase):
         self.assertIn("saib-register", buf.getvalue())
 
     def test_submit_results_skips_duplicates_and_continues(self):
-        from types import SimpleNamespace
         from unittest.mock import patch
         from simple_ai_benchmarking import database as db
 
@@ -226,13 +281,12 @@ class TestSubmissionOutcomes(unittest.TestCase):
             return next(outcomes)
 
         with patch.object(db, "submit_benchmark_result_token_auth", fake_submit):
-            db.submit_results(["a", "b", "c"], SimpleNamespace(), "http://x", "tok")
+            db.submit_results(["a", "b", "c"], "http://x", "tok")
 
         # The duplicate ("b") is skipped without aborting; "c" still gets published.
         self.assertEqual(attempted, ["a", "b", "c"])
 
     def test_submit_results_stops_on_hard_failure(self):
-        from types import SimpleNamespace
         from unittest.mock import patch
         from simple_ai_benchmarking import database as db
 
@@ -244,7 +298,7 @@ class TestSubmissionOutcomes(unittest.TestCase):
             return next(outcomes)
 
         with patch.object(db, "submit_benchmark_result_token_auth", fake_submit):
-            db.submit_results(["a", "b", "c"], SimpleNamespace(), "http://x", "tok")
+            db.submit_results(["a", "b", "c"], "http://x", "tok")
 
         # A genuine failure still aborts: "c" is never attempted.
         self.assertEqual(attempted, ["a", "b"])

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -5,6 +5,8 @@ from simple_ai_benchmarking.experimental.runpod_runner import (
     DONE_MARKER,
     PIP_BASE,
     PIP_LOWBIT,
+    TORCHAO_CU128_INDEX,
+    TORCHAO_TORCH28,
     build_config,
     build_container_script,
     build_pod_body,
@@ -72,7 +74,25 @@ def test_script_both_runs_pt_then_llm_and_publishes():
     # Register must precede publish so unknown-profile rejections are avoided.
     assert script.index("saib-register results_pt.csv") < script.index("saib-pub results_pt.csv")
     assert script.index("saib-register llm_results.csv") < script.index("saib-pub-llm llm_results.csv")
+    assert 'saib-pt --publish-each --non-interactive --database-url "${URL}"' in script
+    assert '--publish-each --non-interactive --database-url "${URL}"' in script
     assert script.strip().splitlines()[-1] == f'echo "{DONE_MARKER}"'
+
+
+def test_blackwell_script_pins_torchao_to_torch28_compatible_release():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "llm"])
+    script = build_container_script(cfg)
+
+    assert (
+        f"pip install --extra-index-url {TORCHAO_CU128_INDEX} "
+        f'"{TORCHAO_TORCH28}" "{PIP_LOWBIT}"'
+    ) in script
+
+
+def test_non_lowbit_script_does_not_install_torchao():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA RTX A6000"])
+
+    assert "torchao==" not in build_container_script(cfg)
 
 
 def test_script_self_terminates_and_caps_threads_by_default():
@@ -104,6 +124,7 @@ def test_no_publish_skips_upload():
     assert "saib-pt" in script
     assert "saib-pub" not in script
     assert "saib-register" not in script
+    assert "--publish-each" not in script
 
 
 def test_script_never_contains_the_token():


### PR DESCRIPTION
**Why:** Completed benchmark rows were only written and published after an entire run finished, so late hangs or timeout kills could lose all earlier workload results. RunPod low-bit installs also needed a torchao build compatible with the torch 2.8 CUDA 12.8 image.\n\n**What:**\n- Export CSV results after each completed workload and add an optional per-workload publish callback.\n- Add token-auth incremental registration/publishing for CV and LLM runs behind --publish-each.\n- Wire --publish-each into saib-pt, saib-llm, and RunPod while keeping final register/publish backstops.\n- Pin RunPod Blackwell low-bit installs to torchao==0.13.0+cu128 and use torchao PerRow FP8 quantization.\n- Bump package version to 0.12.0.\n\n**Test:**\n- python3 -m compileall simple_ai_benchmarking tests\n- uv run pytest -q\n- uv run saib-runpod --dry-run --gpu "NVIDIA RTX A6000" --workload both