### PR TITLE
feat: add vLLM FP8/FP4 benchmark workload to the RunPod runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,24 @@ saib-runpod --gpu "NVIDIA H100 80GB HBM3" --cloud-type SECURE \
 
 > ⚠️ Never pair `[pt,lowbit]` with the torch 2.4 image. The automatic RunPod profile pins the CUDA wheel `torchao==0.13.0+cu128`, the release built for its torch 2.8 image; custom image/pip overrides must select a torchao version compatible with their torch build.
 
+#### FP8 / FP4 via vLLM (`--workload vllm`)
+
+The in-process `torchao` low-bit backends above are experimental. For a reliable FP8/FP4 benchmark, `--workload vllm` instead serves a small model with [vLLM](https://docs.vllm.ai) (production paged-attention KV cache + mature quantization kernels) and benchmarks it through SAIB's `openai-compatible` backend. SAIB is installed torch-free (the HTTP client needs no torch); vLLM is pip-installed on the pod and brings its own torch. This workload is **standalone and never part of the default run** — you opt in explicitly.
+
+```bash
+# FP8 (online dynamic quant of bf16 weights) — works on Ada/Hopper/Blackwell:
+saib-runpod --gpu "NVIDIA GeForce RTX 4090" --cloud-type SECURE --workload vllm
+
+# FP4 (NVFP4) — Blackwell only, needs a pre-quantized ModelOpt NVFP4 checkpoint:
+saib-runpod --gpu "NVIDIA B200" --workload vllm \
+  --vllm-quant nvfp4 --vllm-model nvidia/<some-nvfp4-checkpoint>
+```
+
+The vLLM workload defaults to the torch 2.8 / CUDA 12.8 image on every GPU (so prefer SECURE/datacenter hosts, host driver ≥ 12.8). A small ungated model (`Qwen/Qwen2.5-0.5B-Instruct`, ~1 GB) is used so the checkpoint downloads in seconds. Flags: `--vllm-model`, `--vllm-quant fp8|nvfp4|none`, `--vllm-max-model-len`. FP8 needs no special checkpoint; NVFP4 currently requires a pre-quantized checkpoint passed via `--vllm-model`.
+
 **GPU names** are the RunPod GPU *ids*, e.g. `NVIDIA GeForce RTX 4090`, `NVIDIA H100 80GB HBM3` (H100 SXM), `NVIDIA H200`, `NVIDIA B200` — not the short display names. List them with `python -c "import runpod,os; runpod.api_key=os.environ['RUNPOD_API_KEY']; print('\n'.join(g['id'] for g in runpod.get_gpus()))"`.
 
-Useful flags: `--workload pt|llm|both` (default `both`), `--gpu "A,B,C"` (comma-separated fallback list; RunPod picks by availability), `--cloud-type SECURE|COMMUNITY` (default `SECURE`), `--capacity-wait SECONDS` (keep retrying while RunPod has no capacity, with backoff), `--image`/`--pip-spec` (override the auto profile), `--pt-args`/`--llm-args "-w 0 1"` (passed to the benchmark commands), `--pt-timeout`/`--llm-timeout SECONDS` (per-step hang caps), `--no-publish`, `--keep` (do **not** self-terminate — you must delete the pod yourself), and `--dry-run` (print the plan and the exact container script without creating anything — no API key needed). The database token is provided to the pod as an env var, never baked into the image or the script string.
+Useful flags: `--workload pt|llm|vllm|both` (default `both`; `vllm` is standalone, see above), `--gpu "A,B,C"` (comma-separated fallback list; RunPod picks by availability), `--cloud-type SECURE|COMMUNITY` (default `SECURE`), `--capacity-wait SECONDS` (keep retrying while RunPod has no capacity, with backoff), `--image`/`--pip-spec` (override the auto profile), `--pt-args`/`--llm-args "-w 0 1"` (passed to the benchmark commands), `--pt-timeout`/`--llm-timeout SECONDS` (per-step hang caps), `--no-publish`, `--keep` (do **not** self-terminate — you must delete the pod yourself), and `--dry-run` (print the plan and the exact container script without creating anything — no API key needed). The database token is provided to the pod as an env var, never baked into the image or the script string.
 
 #### Launch a whole fleet
 

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -109,6 +109,26 @@ BLACKWELL_MARKERS = (
 # default run everywhere; run them explicitly via --llm-args if needed.
 LLM_W_DEFAULT = "0 1"
 
+# vLLM FP8/FP4 benchmark (`--workload vllm`). vLLM provides the production
+# paged-attention KV cache and the low-bit kernels; SAIB only drives it over HTTP via
+# the openai-compatible backend, so no torchao and no SAIB [pt] extra are involved.
+# This is a separate, opt-in workload -- never part of the default `saib-llm` run.
+#  - fp8: online dynamic FP8_E4M3 quant of the bf16 weights; Ada (SM 8.9+) or Blackwell.
+#  - nvfp4: needs a pre-quantized ModelOpt NVFP4 checkpoint AND a Blackwell GPU; pass
+#    the checkpoint repo id via --vllm-model (vLLM auto-detects modelopt_fp4).
+# Qwen2.5-0.5B-Instruct is ~1 GB (downloads in seconds) yet a realistic decoder-only
+# LM (GQA, RoPE, SwiGLU), so it exercises a true KV-cache decode path.
+VLLM_DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+VLLM_DEFAULT_QUANT = "fp8"
+VLLM_PORT = 8000
+VLLM_MAX_MODEL_LEN = 4096
+# vLLM ships its own torch build, so install SAIB without the [pt] extra (the
+# openai-compatible client is pure HTTP) to avoid fighting over torch/transformers.
+VLLM_SAIB_SPEC = (
+    "simple-ai-benchmarking@git+"
+    "https://github.com/TimoIllusion/simple-ai-benchmarking.git@main"
+)
+
 DONE_MARKER = "SAIB_ALL_DONE"
 
 
@@ -128,9 +148,12 @@ class Config:
     gpus: List[str]
     image: str
     pip_spec: str
-    workload: str  # "pt" | "llm" | "both"
+    workload: str  # "pt" | "llm" | "vllm" | "both"
     pt_args: str
     llm_args: str
+    vllm_model: str
+    vllm_quant: str
+    vllm_max_model_len: int
     database_url: str
     disk_gb: int
     cloud_type: str
@@ -160,6 +183,17 @@ def resolve_profile(cfg: Config) -> None:
     and can fail to start on older-driver non-Blackwell hosts."""
     lead = cfg.gpus[0] if cfg.gpus else ""
     blackwell = is_blackwell(lead)
+
+    if cfg.workload == "vllm":
+        # vLLM needs a recent torch/CUDA, so default to the cu128 (torch 2.8) image
+        # on every GPU (FP8 works on Ada too; that host just needs driver >= 12.8 --
+        # prefer SECURE). SAIB is installed torch-free; vLLM is pip-installed in the
+        # workload block and brings its own torch.
+        if not cfg.image_was_set:
+            cfg.image = BLACKWELL_IMAGE
+        if not cfg.pip_was_set:
+            cfg.pip_spec = VLLM_SAIB_SPEC
+        return
 
     if not cfg.image_was_set:
         cfg.image = BLACKWELL_IMAGE if blackwell else DEFAULT_IMAGE
@@ -245,6 +279,56 @@ def _llm_block(cfg: Config) -> str:
     return "\n".join(lines)
 
 
+def _vllm_block(cfg: Config) -> str:
+    """Serve a small model with vLLM (FP8/FP4) and benchmark it through SAIB's
+    openai-compatible backend. vLLM owns the KV cache and the quantization kernels;
+    SAIB just drives the HTTP API and publishes the result like any other LLM run."""
+    quant = (cfg.vllm_quant or "none").lower()
+    quant_arg = "" if quant == "none" else f" --quantization {quant}"
+    accel = "vllm-bf16" if quant == "none" else f"vllm-{quant}"
+    model = cfg.vllm_model
+    base = f"http://localhost:{VLLM_PORT}"
+    publish_args = (
+        ' --publish-each --non-interactive --database-url "${URL}"'
+        if cfg.publish
+        else ""
+    )
+    # Readiness probe via python (guaranteed present in every pytorch image; curl is
+    # not), exit 0 only on HTTP 200 from /health.
+    health = (
+        "python -c \"import urllib.request,sys; "
+        f"sys.exit(0 if urllib.request.urlopen('{base}/health',timeout=5).status==200 "
+        'else 1)"'
+    )
+    lines = [
+        'echo "== [vllm] installing vLLM =="',
+        "pip install vllm || echo 'WARN vllm install failed'",
+        f'echo "== [vllm] serving {model} (quant={quant}) on port {VLLM_PORT} =="',
+        # Background server; logs to a file. vLLM exposes /health once it is ready.
+        f'vllm serve "{model}"{quant_arg} --port {VLLM_PORT} '
+        f"--max-model-len {cfg.vllm_max_model_len} --download-dir /workspace/hf "
+        "> /workspace/vllm.log 2>&1 &",
+        "VLLM_PID=$!",
+        'echo "== [vllm] waiting for server (up to ~10 min: download + load) =="',
+        f"for i in $(seq 1 120); do {health} >/dev/null 2>&1 && break; sleep 5; done",
+        f'{health} >/dev/null 2>&1 '
+        '|| { echo "WARN vllm server not ready"; tail -n 60 /workspace/vllm.log; }',
+        'echo "== [vllm] running benchmark (timeout ${LLM_TIMEOUT}s) =="',
+        f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm --backend openai-compatible '
+        f'--base-url "{base}" --model "{model}" --accelerator "{accel}"{publish_args} '
+        '|| echo "WARN saib-llm vllm rc=$?"',
+        'kill "$VLLM_PID" >/dev/null 2>&1 || true',
+    ]
+    if cfg.publish:
+        lines += [
+            'saib-register llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN register vllm"',
+            'saib-pub-llm llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
+            '--database-url "${URL}" --non-interactive || echo "WARN pub vllm"',
+        ]
+    return "\n".join(lines)
+
+
 def build_container_script(cfg: Config) -> str:
     """The bash exec'd by the pod's dockerStartCmd. The DB token is read from the
     pod env (``AI_BENCHMARK_DATABASE_TOKEN``), never interpolated into the text, so
@@ -271,6 +355,8 @@ def build_container_script(cfg: Config) -> str:
         blocks.append(_pt_block(cfg))
     if cfg.workload in ("llm", "both"):
         blocks.append(_llm_block(cfg))
+    if cfg.workload == "vllm":
+        blocks.append(_vllm_block(cfg))
     blocks.append(f'echo "{DONE_MARKER}"')
     return "\n".join(blocks)
 
@@ -370,8 +456,10 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="RunPod gpuTypeId, or a comma-separated fallback list (RunPod picks by availability).",
     )
     parser.add_argument(
-        "--workload", choices=["pt", "llm", "both"], default="both",
-        help="Which benchmark(s) to run on the pod (default: both).",
+        "--workload", choices=["pt", "llm", "vllm", "both"], default="both",
+        help="Which benchmark(s) to run on the pod (default: both). 'vllm' serves a "
+        "small model with vLLM (FP8/FP4) and benchmarks it via the openai-compatible "
+        "backend; it is standalone (not part of 'both').",
     )
     parser.add_argument(
         "--image", default=None,
@@ -385,6 +473,21 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--llm-args", default=None,
         help="Extra args for saib-llm, e.g. '-w 0 1'. Default: the default workload set (-w 0 1).",
+    )
+    parser.add_argument(
+        "--vllm-model", default=VLLM_DEFAULT_MODEL,
+        help=f"Model served by vLLM for --workload vllm. Default: {VLLM_DEFAULT_MODEL} "
+        "(small, ungated). For nvfp4 pass a pre-quantized ModelOpt NVFP4 checkpoint.",
+    )
+    parser.add_argument(
+        "--vllm-quant", default=VLLM_DEFAULT_QUANT,
+        help="vLLM quantization for --workload vllm: 'fp8' (online, Ada/Blackwell), "
+        "'nvfp4' (pre-quantized checkpoint, Blackwell only), or 'none' (bf16). "
+        f"Default: {VLLM_DEFAULT_QUANT}.",
+    )
+    parser.add_argument(
+        "--vllm-max-model-len", type=int, default=VLLM_MAX_MODEL_LEN,
+        help=f"Max model/context length for the vLLM server (default: {VLLM_MAX_MODEL_LEN}).",
     )
     parser.add_argument("--database-url", default=DEFAULT_DATABASE_URL)
     parser.add_argument("--disk-gb", type=int, default=40)
@@ -418,6 +521,9 @@ def build_config(args: argparse.Namespace) -> Config:
         workload=args.workload,
         pt_args=args.pt_args,
         llm_args=args.llm_args or "",
+        vllm_model=args.vllm_model,
+        vllm_quant=args.vllm_quant,
+        vllm_max_model_len=args.vllm_max_model_len,
         database_url=args.database_url,
         disk_gb=args.disk_gb,
         cloud_type=args.cloud_type,
@@ -443,6 +549,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         log(f"Workload: {cfg.workload}  GPUs: {cfg.gpus}  image: {cfg.image}")
         log(f"pip-spec: {cfg.pip_spec}")
         log(f"pt-args: '{cfg.pt_args}'  llm-args: '{cfg.llm_args}'  publish: {cfg.publish}")
+        if cfg.workload == "vllm":
+            log(f"vllm-model: {cfg.vllm_model}  vllm-quant: {cfg.vllm_quant}  "
+                f"max-model-len: {cfg.vllm_max_model_len}")
         print("\n--- container script (dockerStartCmd: bash -lc) ---")
         print(script)
         print("--- end container script ---")

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.12.2"
+VERSION = "0.13.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -7,6 +7,8 @@ from simple_ai_benchmarking.experimental.runpod_runner import (
     PIP_LOWBIT,
     TORCHAO_CU128_INDEX,
     TORCHAO_TORCH28,
+    VLLM_DEFAULT_MODEL,
+    VLLM_SAIB_SPEC,
     build_config,
     build_container_script,
     build_pod_body,
@@ -118,6 +120,49 @@ def test_workload_llm_only_skips_pt():
     script = build_container_script(cfg)
     assert "saib-llm" in script
     assert "saib-pt" not in script
+
+
+def test_workload_vllm_serves_and_benchmarks_via_openai_compatible():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm"])
+    script = build_container_script(cfg)
+    # Installs vLLM, serves the default small model with FP8, waits for /health,
+    # then benchmarks through the openai-compatible backend -- in that order.
+    assert "pip install vllm" in script
+    assert f'vllm serve "{VLLM_DEFAULT_MODEL}" --quantization fp8' in script
+    assert script.index("vllm serve") < script.index("/health")
+    assert script.index("/health") < script.index("saib-llm --backend openai-compatible")
+    assert "--base-url \"http://localhost:8000\"" in script
+    # Standalone vLLM workload does not run the pt/llm benchmarks.
+    assert "saib-pt" not in script
+    assert "-w 0 1" not in script
+    # Register precedes publish, and the script still ends with the done marker.
+    assert script.index("saib-register llm_results.csv") < script.index("saib-pub-llm llm_results.csv")
+    assert script.strip().splitlines()[-1] == f'echo "{DONE_MARKER}"'
+
+
+def test_workload_vllm_uses_cu128_image_and_torchfree_saib():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA GeForce RTX 4090", "--workload", "vllm"])
+    # vLLM needs a recent torch/CUDA, so even a non-Blackwell GPU gets the cu128
+    # image, and SAIB is installed without the [pt] extra (vLLM brings torch).
+    assert cfg.image == BLACKWELL_IMAGE
+    assert cfg.pip_spec == VLLM_SAIB_SPEC
+    assert "[pt]" not in cfg.pip_spec
+    assert "torchao==" not in build_container_script(cfg)
+
+
+def test_workload_vllm_quant_options():
+    nvfp4 = _config(
+        ["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm",
+         "--vllm-quant", "nvfp4", "--vllm-model", "nvidia/some-fp4-ckpt"]
+    )
+    script = build_container_script(nvfp4)
+    assert 'vllm serve "nvidia/some-fp4-ckpt" --quantization nvfp4' in script
+    assert '--accelerator "vllm-nvfp4"' in script
+
+    bf16 = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm", "--vllm-quant", "none"])
+    bf16_script = build_container_script(bf16)
+    assert "--quantization" not in bf16_script
+    assert '--accelerator "vllm-bf16"' in bf16_script
 
 
 def test_no_publish_skips_upload():


### PR DESCRIPTION
**Why:** The in-process `torchao` FP8/FP4 backends are experimental and not producing reliable results. vLLM is the production reference for low-bit LLM inference (paged-attention KV cache + mature FP8/NVFP4 kernels), so leaning on it gives a realistic, working low-bit benchmark with far less custom code.

**What:**
- Add `saib-runpod --workload vllm`: serve a small model with vLLM and benchmark it through the existing `openai-compatible` backend.
- vLLM is pip-installed on the pod and owns torch; SAIB installs torch-free (the openai-compatible client is pure HTTP), avoiding torch/transformers conflicts. Defaults to the cu128 (torch 2.8) image on every GPU.
- New flags: `--vllm-model` (default `Qwen/Qwen2.5-0.5B-Instruct`, ~1 GB ungated), `--vllm-quant` (`fp8` online / `nvfp4` pre-quantized checkpoint / `none`), `--vllm-max-model-len`. FP8 works on Ada/Hopper/Blackwell; NVFP4 is Blackwell-only and needs a pre-quantized ModelOpt checkpoint.
- Container script installs vLLM, serves in the background, waits on `/health` (python probe, no curl dependency), benchmarks, then registers + publishes.
- Standalone workload — never part of the default run or `--workload both`.
- Bump version to 0.13.0.

**Test:** `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q` (94 passed). Generated container script verified via `saib-runpod --dry-run --workload vllm`. Note: a live RunPod `--workload vllm` pod has not yet been run end-to-end (vLLM wheel resolution on the cu128 image + live FP8 run unverified).