### PR TITLE
feat: small HF default model and heavier default LLM load

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ Four backends are supported — two self-contained local PyTorch backends and tw
   saib-llm --backend pytorch-simple-transformer --device cuda
   ```
 
-- `huggingface-causal` — a real model architecture built **random-initialized from its config** (only `config.json` is fetched, no weight download), default `Qwen/Qwen3-1.7B`, defaults to BF16. Uses the model's built-in KV cache, so time-to-first-token reflects a real prefill. Requires `transformers`:
+- `huggingface-causal` — a real model architecture built **random-initialized from its config** (only `config.json` is fetched, no weight download), default `Qwen/Qwen2.5-0.5B-Instruct`, defaults to BF16. Uses the model's built-in KV cache, so time-to-first-token reflects a real prefill. Requires `transformers`:
 
   ```bash
-  saib-llm --backend huggingface-causal --model Qwen/Qwen3-1.7B --device cuda
+  saib-llm --backend huggingface-causal --model Qwen/Qwen2.5-0.5B-Instruct --device cuda
   ```
 
-  For FP8/FP4 numbers on the same architecture, serve it with vLLM and benchmark through `openai-compatible` (below) — that exercises production paged-attention and real low-bit kernels rather than a synthetic cast.
+  The default 0.5B keeps the no-arg run portable. For the headline cross-engine comparison, run the 7B explicitly (`--model Qwen/Qwen2.5-7B-Instruct`, needs a ≥24 GB GPU) and benchmark the **same** model under vLLM (FP8/FP4/bf16) via `saib-runpod --workload vllm` — that exercises production paged-attention and real low-bit kernels rather than a synthetic cast.
 
 - `openai-compatible` — benchmark any server exposing the OpenAI `/v1/chat/completions` API (e.g. vLLM, llama.cpp server, LM Studio, OpenAI itself):
 
@@ -130,9 +130,9 @@ The benchmark performs configurable warmup and measured requests (optionally con
 Common options (see `saib-llm -h` for the full list):
 
 - `-w` / `--workloads` — when no `--backend` is given, 0-based indices selecting which of the default workloads to run, e.g. `-w 0` for only the first (simple transformer) or `-w 1` for only the second (Hugging Face causal LM). Default: run all (mirrors `saib-pt -w`)
-- `--requests` / `--warmup-requests` — number of measured / warmup requests (default `10` / `1`)
+- `--requests` / `--warmup-requests` — number of measured / warmup requests (default `32` / `2`)
 - `--repetitions` — number of times the measurement is repeated and averaged (default `3`); for paid HTTP endpoints, lower this to reduce cost
-- `--concurrency` — for HTTP backends (`openai-compatible`, `ollama`), the number of in-flight concurrent requests; for the local PyTorch backends, the batch size processed in a single batched forward pass (default `1`)
+- `--concurrency` — for HTTP backends (`openai-compatible`, `ollama`), the number of in-flight concurrent requests; for the local PyTorch backends, the batch size processed in a single batched forward pass (default `8`)
 - `--prompt-tokens` / `--generated-tokens` — prompt and generation lengths (default `2048` / `256`)
 - `--context-length` — model context window (default `4096`)
 - `--device` — torch device for the local backends, e.g. `cpu`, `cuda`, `mps` (default `cpu`)

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -65,9 +65,12 @@ DEFAULT_LLM_BACKENDS = (
 
 # Default Hugging Face causal LM for the huggingface-causal backend. Only the
 # model config is fetched and the weights are randomly initialised (approach B),
-# so no large checkpoint is downloaded. Qwen3 is open (Apache-2.0, ungated) and
-# recent. Override with --model <hf_repo_id>.
-DEFAULT_HF_MODEL = "Qwen/Qwen3-1.7B"
+# so no large checkpoint is downloaded. Qwen2.5 is open (Apache-2.0, ungated); the
+# 0.5B size keeps the default run portable (fits modest GPUs, builds in seconds).
+# For the headline cross-engine comparison run the 7B explicitly, e.g.
+# `--model Qwen/Qwen2.5-7B-Instruct`, and benchmark the same model under vLLM via
+# `saib-runpod --workload vllm`. Override with --model <hf_repo_id>.
+DEFAULT_HF_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -95,10 +98,13 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--base-url", default=None)
     parser.add_argument("--model", default="SimpleTransformerLM")
-    parser.add_argument("--requests", type=int, default=10)
-    parser.add_argument("--warmup-requests", type=int, default=1)
+    # Defaults put real load on the device: for the local backends concurrency is
+    # the batch size of one forward pass, so concurrency=8 / requests=32 exercises
+    # batched prefill+decode rather than a single-sequence trickle.
+    parser.add_argument("--requests", type=int, default=32)
+    parser.add_argument("--warmup-requests", type=int, default=2)
     parser.add_argument("--repetitions", type=int, default=3)
-    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--concurrency", type=int, default=8)
     parser.add_argument("--prompt-tokens", type=int, default=2048)
     parser.add_argument("--generated-tokens", type=int, default=256)
     parser.add_argument("--context-length", type=int, default=4096)

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.14.0"
+VERSION = "0.15.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_hf_causal.py
+++ b/tests/test_hf_causal.py
@@ -72,11 +72,11 @@ def test_hf_workload_resolves_config_from_raw_repo_id(monkeypatch):
     config = LLMGenerationConfig(
         backend=HF_CAUSAL_BACKEND,
         device_name="cpu",
-        model="Qwen/Qwen3-1.7B",
+        model="Qwen/Qwen2.5-0.5B-Instruct",
         compute_precision="BF16",
     )
     HuggingFaceCausalGeneration(config).setup()
-    assert seen["model_id"] == "Qwen/Qwen3-1.7B"
+    assert seen["model_id"] == "Qwen/Qwen2.5-0.5B-Instruct"
 
 
 def test_hf_workload_rejects_unknown_precision(monkeypatch):

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -35,9 +35,14 @@ def test_saib_llm_runs_default_local_workloads_with_no_args(monkeypatch):
     assert configs[0].model == "SimpleTransformerLM"
     assert configs[0].device_name == get_device_name_pytorch()
     assert configs[0].base_url == ""
-    # The HF backend gets a real repo id and a bf16 default.
-    assert configs[1].model
+    # The HF backend defaults to the small Qwen2.5 (portable) at bf16.
+    assert configs[1].model == "Qwen/Qwen2.5-0.5B-Instruct"
     assert configs[1].compute_precision == "BF16"
+    # Both default workloads put real (batched) load on the device.
+    for c in configs:
+        assert c.concurrency == 8
+        assert c.requests == 32
+        assert c.warmup_requests == 2
 
 
 def test_saib_llm_only_supports_the_remaining_backends():


### PR DESCRIPTION
**Why:** The default LLM run should be portable (no big download, fits modest GPUs) yet actually load the device. The 7B comparison and FP8/FP4 are manual paths, so the default HF workload uses the small Qwen2.5-0.5B and both default workloads run under batched load instead of a single-sequence trickle.

**What:**
- Default `huggingface-causal` model → `Qwen/Qwen2.5-0.5B-Instruct` (was Qwen3-1.7B).
- Heavier default load: `--concurrency 8`, `--requests 32`, `--warmup-requests 2`.
- README: backend/default-model/options updated; 7B + vLLM framed as the manual cross-engine comparison.
- Bump version to 0.15.0.

**Test:** `python3 -m compileall simple_ai_benchmarking tests` + `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q` → 81 passed. Updated the default-run test to assert the small model + new load defaults.