### PR TITLE
feat: multi-precision vLLM runs and serving_engine metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,18 +227,18 @@ Blackwell is special-cased automatically because it *cannot* run on the torch 2.
 
 #### FP8 / FP4 via vLLM (`--workload vllm`)
 
-For an FP8/FP4 benchmark, `--workload vllm` serves a model with [vLLM](https://docs.vllm.ai) (production paged-attention KV cache + mature quantization kernels) and benchmarks it through SAIB's `openai-compatible` backend. SAIB is installed torch-free (the HTTP client needs no torch); vLLM is pip-installed on the pod and brings its own torch. This workload is **standalone and never part of the default run** — you opt in explicitly.
+For FP8/FP4 numbers, `--workload vllm` serves a model with [vLLM](https://docs.vllm.ai) (production paged-attention KV cache + mature quantization kernels) and benchmarks it through SAIB's `openai-compatible` backend. One pod serves the model and benchmarks **several precisions in sequence** (a fresh server per precision, since quantization is a launch-time flag), so `bf16` vs `fp8` vs `fp4` are compared apples-to-apples on the same GPU. Each precision publishes as its own comparable result (tagged `served_by=vllm`). SAIB is installed torch-free (the HTTP client needs no torch); vLLM is pip-installed on the pod and brings its own torch. This workload is **standalone and never part of the default run** — you opt in explicitly, and it pairs with the local `huggingface-causal` run on the same model for a PyTorch-vs-vLLM comparison.
 
 ```bash
-# FP8 (online dynamic quant of bf16 weights) — works on Ada/Hopper/Blackwell:
+# Default: benchmark bf16 then fp8 on the 7B baseline (Ada/Hopper/Blackwell):
 saib-runpod --gpu "NVIDIA GeForce RTX 4090" --cloud-type SECURE --workload vllm
 
-# FP4 (NVFP4) — Blackwell only, needs a pre-quantized ModelOpt NVFP4 checkpoint:
+# Add FP4 (NVFP4) — Blackwell only, needs a pre-quantized ModelOpt NVFP4 checkpoint:
 saib-runpod --gpu "NVIDIA B200" --workload vllm \
-  --vllm-quant nvfp4 --vllm-model nvidia/<some-nvfp4-checkpoint>
+  --vllm-precisions bf16,fp8,fp4 --vllm-nvfp4-model nvidia/<some-nvfp4-checkpoint>
 ```
 
-The vLLM workload defaults to the torch 2.8 / CUDA 12.8 image on every GPU (so prefer SECURE/datacenter hosts, host driver ≥ 12.8). A small ungated model (`Qwen/Qwen2.5-0.5B-Instruct`, ~1 GB) is used so the checkpoint downloads in seconds. Flags: `--vllm-model`, `--vllm-quant fp8|nvfp4|none`, `--vllm-max-model-len`. FP8 needs no special checkpoint; NVFP4 currently requires a pre-quantized checkpoint passed via `--vllm-model`.
+The vLLM workload defaults to the torch 2.8 / CUDA 12.8 image on every GPU (so prefer SECURE/datacenter hosts, host driver ≥ 12.8) and a **60 GB** container disk (7B + vLLM + HF cache). The default model is `Qwen/Qwen2.5-7B-Instruct` — the throughput-bound regime where quantization actually pays off. The stack is pinned (`vllm==0.11.0`, `transformers==4.57.1`, `hf_transfer`); requesting `fp4` raises the floor to `vllm>=0.13.0` (reliable SM120 NVFP4) and adds the FlashInfer SM120 env. Flags: `--vllm-model`, `--vllm-precisions bf16,fp8,fp4`, `--vllm-nvfp4-model`, `--vllm-max-model-len`, and the benchmark shape `--vllm-requests`/`--vllm-concurrency`/`--vllm-prompt-tokens`/`--vllm-generated-tokens` (defaults 128/64/256/256). `fp8` needs no special checkpoint (online dynamic quant of the bf16 weights); `fp4` is skipped on non-Blackwell hosts or when no `--vllm-nvfp4-model` is given.
 
 **GPU names** are the RunPod GPU *ids*, e.g. `NVIDIA GeForce RTX 4090`, `NVIDIA H100 80GB HBM3` (H100 SXM), `NVIDIA H200`, `NVIDIA B200` — not the short display names. List them with `python -c "import runpod,os; runpod.api_key=os.environ['RUNPOD_API_KEY']; print('\n'.join(g['id'] for g in runpod.get_gpus()))"`.
 

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -22,7 +22,11 @@ SPEC_VERSION = "2.1"
 # backends stay comparable.
 # Bumped 2.1 -> 2.2 alongside the default thread-pool caps (OMP/BLAS/MKL=8), which
 # change measured throughput; 2.2 results carry fresh profile hashes.
-LLM_SPEC_VERSION = "2.2"
+# Bumped 2.2 -> 2.3 when serving_engine joined the profile: the engine that served
+# the model (vllm / ollama / pytorch / openai) is now part of the benchmark
+# identity, so results are grouped per engine even when they share the
+# openai-compatible protocol. 2.3 results carry fresh profile hashes.
+LLM_SPEC_VERSION = "2.3"
 
 CV_RUNNER_ID = "saib.cv.classification.v2"
 LLM_RUNNER_ID = "saib.llm.generation.v2"
@@ -83,12 +87,14 @@ def build_llm_profile(
     prompt_tokens: int,
     generated_tokens: int,
     concurrency: int,
+    serving_engine: str = "",
 ) -> Dict[str, Any]:
     return {
         "benchmark_family": LLM_BENCHMARK_FAMILY,
         "benchmark_spec_name": LLM_SPEC_NAME,
         "benchmark_spec_version": LLM_SPEC_VERSION,
         "backend_protocol_class": backend,
+        "serving_engine": serving_engine,
         "model": model,
         "benchmark_type": benchmark_type,
         "prompt_token_target": int(prompt_tokens),
@@ -107,8 +113,11 @@ def build_llm_profile(
 
 
 def build_llm_profile_id(profile: Mapping[str, Any]) -> str:
+    # serving_engine is part of the id so e.g. a vLLM-served and an OpenAI-served
+    # run over the same openai-compatible protocol get distinct, readable ids.
+    engine = profile.get("serving_engine") or "na"
     return (
-        f"llm_{profile['backend_protocol_class']}_{profile['model']}_"
+        f"llm_{profile['backend_protocol_class']}_{engine}_{profile['model']}_"
         f"{profile['benchmark_type']}_p{profile['prompt_token_target']}_"
         f"g{profile['generated_token_target']}_ctx{profile['context_length']}_"
         f"c{profile['concurrency']}_v2"

--- a/simple_ai_benchmarking/config_structures.py
+++ b/simple_ai_benchmarking/config_structures.py
@@ -148,6 +148,11 @@ class LLMGenerationConfig:
     quantization: str = "none"
     weight_source: str = "random_weights"
     accelerator: str = "unknown"
+    # Engine that served the model (e.g. "vllm", "ollama", "pytorch"). Empty means
+    # "derive from the backend"; the HTTP backends let a caller (the RunPod vLLM
+    # runner) record which server produced the numbers so they group/compare
+    # cleanly even though they all speak the openai-compatible protocol.
+    served_by: str = ""
     ai_framework_version: str = ""
     ai_framework_extra_info: str = ""
     model_params: int = 0

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -102,15 +102,41 @@ LLM_W_DEFAULT = "0 1"
 # paged-attention KV cache and the low-bit kernels; SAIB only drives it over HTTP via
 # the openai-compatible backend, so no torchao and no SAIB [pt] extra are involved.
 # This is a separate, opt-in workload -- never part of the default `saib-llm` run.
+# One pod serves the model and benchmarks several precisions in sequence (a fresh
+# server per precision, since quantization is a launch-time flag) so bf16 vs fp8 vs
+# fp4 are compared apples-to-apples on the same GPU.
+#  - bf16: native half precision, the baseline.
 #  - fp8: online dynamic FP8_E4M3 quant of the bf16 weights; Ada (SM 8.9+) or Blackwell.
-#  - nvfp4: needs a pre-quantized ModelOpt NVFP4 checkpoint AND a Blackwell GPU; pass
-#    the checkpoint repo id via --vllm-model (vLLM auto-detects modelopt_fp4).
-# Qwen2.5-0.5B-Instruct is ~1 GB (downloads in seconds) yet a realistic decoder-only
-# LM (GQA, RoPE, SwiGLU), so it exercises a true KV-cache decode path.
-VLLM_DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
-VLLM_DEFAULT_QUANT = "fp8"
+#  - fp4 (NVFP4): needs a pre-quantized ModelOpt NVFP4 checkpoint AND a Blackwell GPU
+#    (served with --quantization modelopt_fp4); gated to Blackwell + --vllm-nvfp4-model.
+# The 7B Instruct model is the throughput-bound regime where quantization actually
+# pays off (a 0.5B at low concurrency is overhead-bound and shows ~no fp8 gain).
+VLLM_DEFAULT_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+VLLM_DEFAULT_PRECISIONS = "bf16,fp8"
 VLLM_PORT = 8000
 VLLM_MAX_MODEL_LEN = 4096
+VLLM_DEFAULT_DISK_GB = 60  # 7B weights + vLLM + HF cache; 40 GB hits Errno 28.
+
+# Benchmark shape for the vLLM legs: a throughput-bound regime (high concurrency,
+# short prompt/gen) where fp8/fp4 separate clearly from bf16.
+VLLM_REQUESTS = 128
+VLLM_CONCURRENCY = 64
+VLLM_PROMPT_TOKENS = 256
+VLLM_GENERATED_TOKENS = 256
+
+# Pinned vLLM stack (validated on Blackwell sm_120). transformers has no upper bound
+# in vLLM's own deps, so pip otherwise grabs 5.x and breaks the tokenizer; hf_transfer
+# is required when the image sets HF_HUB_ENABLE_HF_TRANSFER=1. vLLM 0.11.0 has reliable
+# SM120 fp8/bf16; NVFP4 dense SM120 kernels are only reliable from 0.13.0, so the fp4
+# leg raises the floor.
+VLLM_PINS = '"vllm==0.11.0" "transformers==4.57.1" hf_transfer'
+VLLM_PINS_FP4 = '"vllm>=0.13.0" "transformers==4.57.1" hf_transfer'
+# FlashInfer must be told the target is SM120 explicitly for the NVFP4 path.
+VLLM_FP4_ENV = (
+    "FLASHINFER_CUDA_ARCH_LIST=12.0f FLASHINFER_FORCE_SM=120f "
+    "FLASHINFER_DISABLE_VERSION_CHECK=1 "
+)
+
 # vLLM ships its own torch build, so install SAIB without the [pt] extra (the
 # openai-compatible client is pure HTTP) to avoid fighting over torch/transformers.
 VLLM_SAIB_SPEC = (
@@ -141,8 +167,13 @@ class Config:
     pt_args: str
     llm_args: str
     vllm_model: str
-    vllm_quant: str
+    vllm_precisions: str
+    vllm_nvfp4_model: str
     vllm_max_model_len: int
+    vllm_requests: int
+    vllm_concurrency: int
+    vllm_prompt_tokens: int
+    vllm_generated_tokens: int
     database_url: str
     disk_gb: int
     cloud_type: str
@@ -154,6 +185,7 @@ class Config:
     image_was_set: bool = False
     pip_was_set: bool = False
     llm_args_was_set: bool = False
+    disk_was_set: bool = False
 
 
 # --------------------------------------------------------------------------- #
@@ -179,6 +211,8 @@ def resolve_profile(cfg: Config) -> None:
             cfg.image = BLACKWELL_IMAGE
         if not cfg.pip_was_set:
             cfg.pip_spec = VLLM_SAIB_SPEC
+        if not cfg.disk_was_set:
+            cfg.disk_gb = VLLM_DEFAULT_DISK_GB
         return
 
     if not cfg.image_was_set:
@@ -263,20 +297,54 @@ def _llm_block(cfg: Config) -> str:
     return "\n".join(lines)
 
 
-def _vllm_block(cfg: Config) -> str:
-    """Serve a small model with vLLM (FP8/FP4) and benchmark it through SAIB's
-    openai-compatible backend. vLLM owns the KV cache and the quantization kernels;
-    SAIB just drives the HTTP API and publishes the result like any other LLM run."""
-    quant = (cfg.vllm_quant or "none").lower()
-    quant_arg = "" if quant == "none" else f" --quantization {quant}"
-    accel = "vllm-bf16" if quant == "none" else f"vllm-{quant}"
-    model = cfg.vllm_model
-    base = f"http://localhost:{VLLM_PORT}"
-    publish_args = (
-        ' --publish-each --non-interactive --database-url "${URL}"'
-        if cfg.publish
-        else ""
+def _normalize_precision(p: str) -> str:
+    p = p.strip().lower()
+    return "fp4" if p in ("fp4", "nvfp4") else p
+
+
+def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
+    """Return (effective, skipped) precision legs for the vLLM workload.
+
+    fp4 (NVFP4) is gated: it needs a Blackwell GPU *and* a pre-quantized checkpoint
+    (--vllm-nvfp4-model). On any other host, or without the checkpoint, the fp4 leg
+    is skipped (and reported) rather than launched into a guaranteed failure."""
+    blackwell = is_blackwell(cfg.gpus[0] if cfg.gpus else "")
+    effective: List[str] = []
+    skipped: List[str] = []
+    for raw in cfg.vllm_precisions.split(","):
+        if not raw.strip():
+            continue
+        p = _normalize_precision(raw)
+        if p == "fp4" and not (blackwell and cfg.vllm_nvfp4_model):
+            if p not in skipped:
+                skipped.append(p)
+            continue
+        if p not in effective:
+            effective.append(p)
+    return effective, skipped
+
+
+def _vllm_precision_spec(cfg: Config, precision: str):
+    """Map a precision leg to (served_model, serve_quant_flag, env_prefix,
+    compute_precision, quantization_metadata, accelerator_label)."""
+    if precision == "fp4":
+        return (cfg.vllm_nvfp4_model, " --quantization modelopt_fp4",
+                VLLM_FP4_ENV, "fp4", "nvfp4", "vllm-fp4")
+    if precision == "fp8":
+        return (cfg.vllm_model, " --quantization fp8", "", "fp8", "fp8", "vllm-fp8")
+    # bf16 / baseline: native half precision, no quant flag.
+    return (cfg.vllm_model, "", "", "bf16", "none", "vllm-bf16")
+
+
+def _vllm_leg(cfg: Config, precision: str) -> List[str]:
+    """Lines that serve one precision, benchmark it over openai-compatible, publish
+    its own per-precision CSV, and tear the server down before the next leg."""
+    model, quant_serve, env, compute_precision, quant_meta, accel = _vllm_precision_spec(
+        cfg, precision
     )
+    base = f"http://localhost:{VLLM_PORT}"
+    out_base = f"llm_results_vllm_{precision}"
+    log_file = f"/workspace/vllm_{precision}.log"
     # Readiness probe via python (guaranteed present in every pytorch image; curl is
     # not), exit 0 only on HTTP 200 from /health.
     health = (
@@ -285,31 +353,58 @@ def _vllm_block(cfg: Config) -> str:
         'else 1)"'
     )
     lines = [
-        'echo "== [vllm] installing vLLM =="',
-        "pip install vllm || echo 'WARN vllm install failed'",
-        f'echo "== [vllm] serving {model} (quant={quant}) on port {VLLM_PORT} =="',
-        # Background server; logs to a file. vLLM exposes /health once it is ready.
-        f'vllm serve "{model}"{quant_arg} --port {VLLM_PORT} '
+        f'echo "== [vllm:{precision}] serving {model} on port {VLLM_PORT} =="',
+        # Background server; logs to a per-precision file. /health flips to 200 ready.
+        f'{env}vllm serve "{model}"{quant_serve} --port {VLLM_PORT} '
         f"--max-model-len {cfg.vllm_max_model_len} --download-dir /workspace/hf "
-        "> /workspace/vllm.log 2>&1 &",
+        f"> {log_file} 2>&1 &",
         "VLLM_PID=$!",
-        'echo "== [vllm] waiting for server (up to ~10 min: download + load) =="',
-        f"for i in $(seq 1 120); do {health} >/dev/null 2>&1 && break; sleep 5; done",
+        f'echo "== [vllm:{precision}] waiting for server (up to ~15 min: download + load) =="',
+        f"for i in $(seq 1 180); do {health} >/dev/null 2>&1 && break; sleep 5; done",
         f'{health} >/dev/null 2>&1 '
-        '|| { echo "WARN vllm server not ready"; tail -n 60 /workspace/vllm.log; }',
-        'echo "== [vllm] running benchmark (timeout ${LLM_TIMEOUT}s) =="',
+        f'|| {{ echo "WARN vllm[{precision}] not ready"; tail -n 60 {log_file}; }}',
+        f'echo "== [vllm:{precision}] running benchmark (timeout ${{LLM_TIMEOUT}}s) =="',
         f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm --backend openai-compatible '
-        f'--base-url "{base}" --model "{model}" --accelerator "{accel}"{publish_args} '
-        '|| echo "WARN saib-llm vllm rc=$?"',
+        f'--base-url "{base}" --model "{model}" --served-by vllm '
+        f'--accelerator "{accel}" --compute-precision {compute_precision} '
+        f"--quantization {quant_meta} --requests {cfg.vllm_requests} "
+        f"--concurrency {cfg.vllm_concurrency} --prompt-tokens {cfg.vllm_prompt_tokens} "
+        f"--generated-tokens {cfg.vllm_generated_tokens} --out-file-base {out_base} "
+        f'|| echo "WARN saib-llm vllm[{precision}] rc=$?"',
+        # Stop the server and wait for the port to free before the next precision.
         'kill "$VLLM_PID" >/dev/null 2>&1 || true',
+        'wait "$VLLM_PID" 2>/dev/null || true',
     ]
     if cfg.publish:
         lines += [
-            'saib-register llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN register vllm"',
-            'saib-pub-llm llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN pub vllm"',
+            f'saib-register {out_base}.csv -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
+            f'--database-url "${{URL}}" --non-interactive || echo "WARN register vllm[{precision}]"',
+            f'saib-pub-llm {out_base}.csv -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
+            f'--database-url "${{URL}}" --non-interactive || echo "WARN pub vllm[{precision}]"',
         ]
+    return lines
+
+
+def _vllm_block(cfg: Config) -> str:
+    """Serve the model with vLLM and benchmark several precisions in sequence
+    (bf16, fp8, fp4) through SAIB's openai-compatible backend. vLLM owns the KV
+    cache and the quantization kernels; SAIB drives the HTTP API and publishes each
+    precision as its own comparable result (served_by=vllm)."""
+    effective, skipped = resolve_vllm_precisions(cfg)
+    pins = VLLM_PINS_FP4 if "fp4" in effective else VLLM_PINS
+    lines = [
+        'echo "== [vllm] installing vLLM =="',
+        f"pip install {pins} || echo 'WARN vllm install failed'",
+    ]
+    for p in skipped:
+        lines.append(
+            f'echo "== [vllm] skipping {p}: needs a Blackwell GPU and --vllm-nvfp4-model =="'
+        )
+    if not effective:
+        lines.append('echo "WARN no vllm precisions to run"')
+        return "\n".join(lines)
+    for precision in effective:
+        lines += _vllm_leg(cfg, precision)
     return "\n".join(lines)
 
 
@@ -436,9 +531,10 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--workload", choices=["pt", "llm", "vllm", "both"], default="both",
-        help="Which benchmark(s) to run on the pod (default: both). 'vllm' serves a "
-        "small model with vLLM (FP8/FP4) and benchmarks it via the openai-compatible "
-        "backend; it is standalone (not part of 'both').",
+        help="Which benchmark(s) to run on the pod (default: both). 'vllm' serves "
+        "the model with vLLM and benchmarks several precisions (bf16/fp8/fp4) in "
+        "sequence via the openai-compatible backend; it is standalone (not part of "
+        "'both').",
     )
     parser.add_argument(
         "--image", default=None,
@@ -455,21 +551,38 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--vllm-model", default=VLLM_DEFAULT_MODEL,
-        help=f"Model served by vLLM for --workload vllm. Default: {VLLM_DEFAULT_MODEL} "
-        "(small, ungated). For nvfp4 pass a pre-quantized ModelOpt NVFP4 checkpoint.",
+        help=f"Model served by vLLM for the bf16/fp8 legs of --workload vllm. "
+        f"Default: {VLLM_DEFAULT_MODEL}.",
     )
     parser.add_argument(
-        "--vllm-quant", default=VLLM_DEFAULT_QUANT,
-        help="vLLM quantization for --workload vllm: 'fp8' (online, Ada/Blackwell), "
-        "'nvfp4' (pre-quantized checkpoint, Blackwell only), or 'none' (bf16). "
-        f"Default: {VLLM_DEFAULT_QUANT}.",
+        "--vllm-precisions", default=VLLM_DEFAULT_PRECISIONS,
+        help="Comma-separated precisions to benchmark in sequence on one pod: "
+        "'bf16', 'fp8', 'fp4' (a fresh vLLM server per precision). fp4/NVFP4 is "
+        "gated to Blackwell + --vllm-nvfp4-model and otherwise skipped. "
+        f"Default: {VLLM_DEFAULT_PRECISIONS}.",
+    )
+    parser.add_argument(
+        "--vllm-nvfp4-model", default="",
+        help="Pre-quantized ModelOpt NVFP4 checkpoint repo id, served for the fp4 "
+        "leg (Blackwell only). Required to include fp4 in --vllm-precisions.",
     )
     parser.add_argument(
         "--vllm-max-model-len", type=int, default=VLLM_MAX_MODEL_LEN,
         help=f"Max model/context length for the vLLM server (default: {VLLM_MAX_MODEL_LEN}).",
     )
+    parser.add_argument("--vllm-requests", type=int, default=VLLM_REQUESTS,
+                        help=f"Measured requests per vLLM leg (default: {VLLM_REQUESTS}).")
+    parser.add_argument("--vllm-concurrency", type=int, default=VLLM_CONCURRENCY,
+                        help=f"In-flight concurrent requests per vLLM leg (default: {VLLM_CONCURRENCY}).")
+    parser.add_argument("--vllm-prompt-tokens", type=int, default=VLLM_PROMPT_TOKENS,
+                        help=f"Prompt length per vLLM leg (default: {VLLM_PROMPT_TOKENS}).")
+    parser.add_argument("--vllm-generated-tokens", type=int, default=VLLM_GENERATED_TOKENS,
+                        help=f"Generation length per vLLM leg (default: {VLLM_GENERATED_TOKENS}).")
     parser.add_argument("--database-url", default=DEFAULT_DATABASE_URL)
-    parser.add_argument("--disk-gb", type=int, default=40)
+    parser.add_argument(
+        "--disk-gb", type=int, default=None,
+        help="Container disk in GB. Default: 40, or 60 for --workload vllm (7B + vLLM).",
+    )
     parser.add_argument("--cloud-type", choices=["SECURE", "COMMUNITY"], default="SECURE")
     parser.add_argument(
         "--capacity-wait", type=int, default=0,
@@ -501,10 +614,15 @@ def build_config(args: argparse.Namespace) -> Config:
         pt_args=args.pt_args,
         llm_args=args.llm_args or "",
         vllm_model=args.vllm_model,
-        vllm_quant=args.vllm_quant,
+        vllm_precisions=args.vllm_precisions,
+        vllm_nvfp4_model=args.vllm_nvfp4_model,
         vllm_max_model_len=args.vllm_max_model_len,
+        vllm_requests=args.vllm_requests,
+        vllm_concurrency=args.vllm_concurrency,
+        vllm_prompt_tokens=args.vllm_prompt_tokens,
+        vllm_generated_tokens=args.vllm_generated_tokens,
         database_url=args.database_url,
-        disk_gb=args.disk_gb,
+        disk_gb=args.disk_gb if args.disk_gb is not None else 40,
         cloud_type=args.cloud_type,
         publish=not args.no_publish,
         keep=args.keep,
@@ -514,6 +632,7 @@ def build_config(args: argparse.Namespace) -> Config:
         image_was_set=args.image is not None,
         pip_was_set=args.pip_spec is not None,
         llm_args_was_set=args.llm_args is not None,
+        disk_was_set=args.disk_gb is not None,
     )
     resolve_profile(cfg)
     return cfg
@@ -529,8 +648,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         log(f"pip-spec: {cfg.pip_spec}")
         log(f"pt-args: '{cfg.pt_args}'  llm-args: '{cfg.llm_args}'  publish: {cfg.publish}")
         if cfg.workload == "vllm":
-            log(f"vllm-model: {cfg.vllm_model}  vllm-quant: {cfg.vllm_quant}  "
-                f"max-model-len: {cfg.vllm_max_model_len}")
+            effective, skipped = resolve_vllm_precisions(cfg)
+            log(f"vllm-model: {cfg.vllm_model}  precisions: {effective}"
+                + (f"  skipped: {skipped}" if skipped else ""))
+            log(f"max-model-len: {cfg.vllm_max_model_len}  disk-gb: {cfg.disk_gb}  "
+                f"shape: r{cfg.vllm_requests}/c{cfg.vllm_concurrency}/"
+                f"p{cfg.vllm_prompt_tokens}/g{cfg.vllm_generated_tokens}")
         print("\n--- container script (dockerStartCmd: bash -lc) ---")
         print(script)
         print("--- end container script ---")

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -117,6 +117,13 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--ai-framework-version", default="")
     parser.add_argument("--ai-framework-extra-info", default="")
     parser.add_argument("--accelerator", default="unknown")
+    parser.add_argument(
+        "--served-by",
+        default="",
+        help="Engine that serves the model, recorded in the benchmark identity "
+        "(e.g. 'vllm' when benchmarking a vLLM server over --backend "
+        "openai-compatible). Default: derived from the backend.",
+    )
     parser.add_argument("--weight-source", default="")
     parser.add_argument("--device", default=None)
     parser.add_argument("--vocab-size", type=int, default=32000)
@@ -231,6 +238,7 @@ def build_generation_config_from_args(
         quantization=quantization,
         weight_source=weight_source,
         accelerator=accelerator,
+        served_by=args.served_by,
         ai_framework_version=ai_framework_version,
         ai_framework_extra_info=ai_framework_extra_info,
         model_params=args.model_params,

--- a/simple_ai_benchmarking/llm_results.py
+++ b/simple_ai_benchmarking/llm_results.py
@@ -33,6 +33,7 @@ class LLMBenchInfo:
     concurrency: int
     date: str
     weight_source: str = ""
+    serving_engine: str = ""
     benchmark_family: str = field(init=False)
     benchmark_spec_name: str = field(init=False)
     benchmark_spec_version: str = field(init=False)
@@ -54,6 +55,7 @@ class LLMBenchInfo:
             prompt_tokens=self.prompt_tokens,
             generated_tokens=self.generated_tokens,
             concurrency=self.concurrency,
+            serving_engine=self.serving_engine,
         )
         assign_benchmark_identity(
             self,
@@ -129,6 +131,7 @@ class LLMBenchmarkLogger(BaseBenchmarkLogger):
         header = [
             "#RUN",
             "Backend",
+            "Engine",
             "Model",
             "Accelerator",
             "Precision",
@@ -146,6 +149,7 @@ class LLMBenchmarkLogger(BaseBenchmarkLogger):
                 [
                     str(i),
                     result.bench_info.backend,
+                    result.bench_info.serving_engine or "-",
                     result.bench_info.model,
                     result.hw_info.accelerator,
                     result.bench_info.compute_precision,

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.15.0"
+VERSION = "0.16.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -97,6 +97,16 @@ class LLMGenerationWorkload(AIWorkload):
     def _get_backend(self) -> str:
         pass
 
+    def _get_serving_engine(self) -> str:
+        """Engine that served the model, for the benchmark identity/metadata.
+
+        An explicit cfg.served_by wins (the RunPod vLLM runner sets it to "vllm");
+        otherwise each backend supplies a sensible default."""
+        return self.cfg.served_by or self._default_serving_engine()
+
+    def _default_serving_engine(self) -> str:
+        return ""
+
     @abstractmethod
     def _run_warmup(self) -> None:
         pass
@@ -139,6 +149,7 @@ class LLMGenerationWorkload(AIWorkload):
             concurrency=self.cfg.concurrency,
             date=datetime.datetime.now().isoformat(),
             weight_source=self.cfg.weight_source,
+            serving_engine=self._get_serving_engine(),
         )
         performance = LLMPerformanceResult(
             requests=self.cfg.requests,
@@ -245,6 +256,10 @@ class PyTorchLocalGeneration(LLMGenerationWorkload):
 
     def _get_backend(self) -> str:
         return PYTORCH_GENERATION_BACKEND
+
+    def _default_serving_engine(self) -> str:
+        # In-process PyTorch (the simple transformer and the HF causal subclass).
+        return "pytorch"
 
     def _get_ai_framework_name(self) -> str:
         return PYTORCH_GENERATION_BACKEND
@@ -443,6 +458,11 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
     def _get_backend(self) -> str:
         return OPENAI_COMPATIBLE_BACKEND
 
+    def _default_serving_engine(self) -> str:
+        # The protocol is generic; without an explicit --served-by we can only say
+        # it spoke the openai-compatible API. The RunPod vLLM runner sets "vllm".
+        return OPENAI_COMPATIBLE_BACKEND
+
     def _get_ai_framework_name(self) -> str:
         return OPENAI_COMPATIBLE_BACKEND
 
@@ -513,6 +533,9 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
 class OllamaGeneration(HTTPGenerationWorkload):
 
     def _get_backend(self) -> str:
+        return OLLAMA_BACKEND
+
+    def _default_serving_engine(self) -> str:
         return OLLAMA_BACKEND
 
     def _get_ai_framework_name(self) -> str:

--- a/tests/test_benchmark_metadata.py
+++ b/tests/test_benchmark_metadata.py
@@ -5,6 +5,7 @@ from simple_ai_benchmarking.benchmark_metadata import (
     build_cv_profile,
     build_cv_profile_id,
     build_llm_profile,
+    build_llm_profile_id,
     canonical_hash,
 )
 from simple_ai_benchmarking.llm_results import (
@@ -158,8 +159,30 @@ def test_llm_profile_hash_changes_for_comparability_parameters():
         "context_length": 8192,
         "concurrency": 2,
         "backend_protocol_class": "openai-compatible",
+        "serving_engine": "vllm",
     }.items():
         assert canonical_hash(base) != canonical_hash(dict(base, **{key: value}))
+
+
+def test_llm_serving_engine_distinguishes_same_protocol_runs():
+    # Two runs over the same openai-compatible protocol but different engines must
+    # get distinct profile identities (e.g. a vLLM server vs the OpenAI API).
+    common = dict(
+        backend="openai-compatible",
+        model="Qwen2.5-7B-Instruct",
+        benchmark_type="inference",
+        compute_precision="fp8",
+        quantization="fp8",
+        context_length=4096,
+        prompt_tokens=256,
+        generated_tokens=256,
+        concurrency=64,
+    )
+    vllm = build_llm_profile(serving_engine="vllm", **common)
+    openai = build_llm_profile(serving_engine="openai", **common)
+    assert canonical_hash(vllm) != canonical_hash(openai)
+    assert build_llm_profile_id(vllm) != build_llm_profile_id(openai)
+    assert "vllm" in build_llm_profile_id(vllm)
 
 
 def test_cv_csv_export_contains_benchmark_metadata():

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -140,6 +140,7 @@ def _args(**overrides) -> argparse.Namespace:
         ai_framework_version="",
         ai_framework_extra_info="",
         accelerator="cpu",
+        served_by="",
         weight_source="",
         device="cpu",
         vocab_size=32000,

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -215,5 +215,7 @@ def test_generation_workload_result_is_exportable():
     row = logger.to_dataframe().iloc[0].to_dict()
 
     assert row["bench_info_benchmark_family"] == "llm"
-    assert row["bench_info_benchmark_spec_version"] == "2.2"
+    assert row["bench_info_benchmark_spec_version"] == "2.3"
     assert row["bench_info_benchmark_payload_hash"]
+    # The local PyTorch backend records its engine as "pytorch".
+    assert row["bench_info_serving_engine"] == "pytorch"

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -112,47 +112,70 @@ def test_workload_llm_only_skips_pt():
     assert "saib-pt" not in script
 
 
-def test_workload_vllm_serves_and_benchmarks_via_openai_compatible():
+def test_workload_vllm_runs_bf16_then_fp8_legs_with_correct_metadata():
     cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm"])
     script = build_container_script(cfg)
-    # Installs vLLM, serves the default small model with FP8, waits for /health,
-    # then benchmarks through the openai-compatible backend -- in that order.
-    assert "pip install vllm" in script
+    # Default precisions bf16,fp8: a fresh vLLM server per precision, in order.
+    assert '"vllm==0.11.0"' in script and "transformers==4.57.1" in script and "hf_transfer" in script
+    assert script.count("vllm serve") == 2
+    # bf16 leg: no quant flag; fp8 leg: --quantization fp8 -- bf16 served first.
+    assert f'vllm serve "{VLLM_DEFAULT_MODEL}" --port' in script  # bf16, no quant
     assert f'vllm serve "{VLLM_DEFAULT_MODEL}" --quantization fp8' in script
-    assert script.index("vllm serve") < script.index("/health")
+    assert script.index("vllm-bf16") < script.index("vllm-fp8")
+    # Each leg passes the correct metadata to saib-llm (the old Quant=none bug).
+    assert '--served-by vllm' in script
+    assert '--accelerator "vllm-bf16" --compute-precision bf16 --quantization none' in script
+    assert '--accelerator "vllm-fp8" --compute-precision fp8 --quantization fp8' in script
     assert script.index("/health") < script.index("saib-llm --backend openai-compatible")
-    assert "--base-url \"http://localhost:8000\"" in script
-    # Standalone vLLM workload does not run the pt/llm benchmarks.
+    assert '--base-url "http://localhost:8000"' in script
+    # Standalone: no pt/llm default benchmarks; ends with the done marker.
     assert "saib-pt" not in script
-    assert "-w 0 1" not in script
-    # Register precedes publish, and the script still ends with the done marker.
-    assert script.index("saib-register llm_results.csv") < script.index("saib-pub-llm llm_results.csv")
     assert script.strip().splitlines()[-1] == f'echo "{DONE_MARKER}"'
 
 
-def test_workload_vllm_uses_cu128_image_and_torchfree_saib():
+def test_workload_vllm_bumps_disk_and_uses_cu128_torchfree_saib():
     cfg = _config(["--dry-run", "--gpu", "NVIDIA GeForce RTX 4090", "--workload", "vllm"])
     # vLLM needs a recent torch/CUDA, so even a non-Blackwell GPU gets the cu128
-    # image, and SAIB is installed without the [pt] extra (vLLM brings torch).
+    # image, SAIB is installed torch-free, and disk is bumped for the 7B + vLLM.
     assert cfg.image == BLACKWELL_IMAGE
     assert cfg.pip_spec == VLLM_SAIB_SPEC
     assert "[pt]" not in cfg.pip_spec
-    assert "torchao==" not in build_container_script(cfg)
+    assert cfg.disk_gb == 60
+    assert "torchao" not in build_container_script(cfg)
 
 
-def test_workload_vllm_quant_options():
-    nvfp4 = _config(
+def test_workload_vllm_fp4_gated_to_blackwell_with_checkpoint():
+    # Blackwell + an NVFP4 checkpoint: the fp4 leg runs with modelopt_fp4, the
+    # FlashInfer SM120 env, and the bumped vLLM floor.
+    bw = _config(
         ["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm",
-         "--vllm-quant", "nvfp4", "--vllm-model", "nvidia/some-fp4-ckpt"]
+         "--vllm-precisions", "bf16,fp8,fp4", "--vllm-nvfp4-model", "nvidia/ckpt-nvfp4"]
     )
-    script = build_container_script(nvfp4)
-    assert 'vllm serve "nvidia/some-fp4-ckpt" --quantization nvfp4' in script
-    assert '--accelerator "vllm-nvfp4"' in script
+    script = build_container_script(bw)
+    assert script.count("vllm serve") == 3
+    assert 'vllm serve "nvidia/ckpt-nvfp4" --quantization modelopt_fp4' in script
+    assert "FLASHINFER_FORCE_SM=120f" in script
+    assert '--accelerator "vllm-fp4" --compute-precision fp4 --quantization nvfp4' in script
+    assert '"vllm>=0.13.0"' in script  # fp4 raises the vLLM floor
 
-    bf16 = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm", "--vllm-quant", "none"])
-    bf16_script = build_container_script(bf16)
-    assert "--quantization" not in bf16_script
-    assert '--accelerator "vllm-bf16"' in bf16_script
+    # Non-Blackwell, or no checkpoint: fp4 is skipped, not launched.
+    ada = _config(
+        ["--dry-run", "--gpu", "NVIDIA GeForce RTX 4090", "--workload", "vllm",
+         "--vllm-precisions", "bf16,fp8,fp4"]
+    )
+    ada_script = build_container_script(ada)
+    assert ada_script.count("vllm serve") == 2
+    assert "modelopt_fp4" not in ada_script
+    assert "skipping fp4" in ada_script
+    assert '"vllm==0.11.0"' in ada_script  # no fp4 -> the 0.11 pin
+
+
+def test_workload_vllm_publishes_each_precision_register_before_pub():
+    cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm"])
+    script = build_container_script(cfg)
+    for precision in ("bf16", "fp8"):
+        csv = f"llm_results_vllm_{precision}.csv"
+        assert script.index(f"saib-register {csv}") < script.index(f"saib-pub-llm {csv}")
 
 
 def test_no_publish_skips_upload():


### PR DESCRIPTION
**Why:** Make the manual vLLM endpoint benchmarking first-class. Previously the `--workload vllm` path benchmarked a single quant and forgot to pass the precision/quantization to `saib-llm` (publishing `Quant=none` rows), and there was no way to tell a vLLM-served result apart from a generic OpenAI/Ollama one. This wires up an apples-to-apples FP8/FP4/bf16 comparison on one GPU and records which engine served the model.

**What:**
- **Multi-precision vLLM runner:** `--workload vllm` serves the model and benchmarks several precisions in sequence on one pod (fresh server per precision) — `bf16,fp8` by default, plus `fp4`/NVFP4 gated to Blackwell + `--vllm-nvfp4-model` (served with `modelopt_fp4` + FlashInfer SM120 env). Each leg passes the correct `--compute-precision`/`--quantization`/`--served-by vllm` and publishes its own per-precision CSV (register before publish).
- **serving_engine dimension:** new `--served-by` flag on `saib-llm` (backends default to `pytorch`/`ollama`/`openai-compatible`; the runner sets `vllm`), threaded into `build_llm_profile` + the profile id and shown as an `Engine` column. Bump `LLM_SPEC_VERSION` 2.2 → 2.3.
- **Pinned vLLM stack:** `vllm==0.11.0` / `transformers==4.57.1` / `hf_transfer`; `fp4` raises the floor to `vllm>=0.13.0`. Default vLLM model → `Qwen/Qwen2.5-7B-Instruct`; benchmark-shape flags (`--vllm-requests/--vllm-concurrency/--vllm-prompt-tokens/--vllm-generated-tokens`, defaults 128/64/256/256); vLLM container disk bumped to 60 GB.
- README vLLM section rewritten; bump version to 0.16.0.

**Test:** `python3 -m compileall simple_ai_benchmarking tests` + `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q` → 83 passed. Added metadata tests (serving_engine changes the hash + id; spec 2.3) and rewrote the runpod vLLM tests (bf16→fp8 ordering, correct per-leg metadata flags, fp4 Blackwell/checkpoint gate, pins, disk 60, per-precision register-before-publish). Smoke-tested `--workload vllm --dry-run` on B200 (3 legs incl. fp4) and RTX 4090 (fp4 skipped, 2 legs).