### PR TITLE
fix: code-review findings (publish/runner correctness + cleanup)

### DIFF
--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -259,13 +259,18 @@ def read_csv_and_create_benchmark_dataset(csv_file_path: str, extra_info: str = 
                     f"Unknown benchmark type: {row['bench_info_workload_type']}"
                 )
 
+            # Per-row, not a reassignment of the `extra_info` parameter: otherwise
+            # the first row's value would leak onto every subsequent row (e.g. a
+            # multi-device CSV would publish every row with row 0's device).
             if extra_info is None:
-                extra_info = row["sw_info_ai_framework_extra_info"]
+                row_extra_info = row["sw_info_ai_framework_extra_info"]
+            else:
+                row_extra_info = extra_info
 
             benchmark_data = BenchmarkData(
                 ai_framework_name=row["sw_info_ai_framework_name"],
                 ai_framework_version=row["sw_info_ai_framework_version"],
-                ai_framework_extra_info=extra_info,
+                ai_framework_extra_info=row_extra_info,
                 python_version=row["sw_info_python_version"],
                 cpu_name=row["hw_info_cpu"],
                 accelerator=row["hw_info_accelerator"],

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -297,23 +297,47 @@ def _llm_block(cfg: Config) -> str:
     return "\n".join(lines)
 
 
-# Precisions the vLLM workload knows how to serve (after alias normalization).
-VLLM_KNOWN_PRECISIONS = ("bf16", "fp8", "fp4")
+@dataclass(frozen=True)
+class _VllmPrecision:
+    serve_quant_flag: str        # appended after `vllm serve "model"`
+    env_prefix: str              # inline env for the serve command (FlashInfer fp4)
+    compute_precision: str       # saib-llm --compute-precision value
+    quantization: str            # saib-llm --quantization metadata
+    uses_nvfp4_checkpoint: bool  # serve cfg.vllm_nvfp4_model instead of vllm_model
+    requires_blackwell: bool     # leg is gated to Blackwell hosts
+    pins: str                    # vLLM pip pins this precision needs
+
+
+# Single source of truth for every vLLM precision leg: serve flags, gating, pins,
+# and the recorded metadata. Adding a precision is one entry here (+ an alias).
+_VLLM_PRECISIONS = {
+    "bf16": _VllmPrecision("", "", "bf16", "none", False, False, VLLM_PINS),
+    "fp8": _VllmPrecision(" --quantization fp8", "", "fp8", "fp8", False, False, VLLM_PINS),
+    "fp4": _VllmPrecision(
+        " --quantization modelopt_fp4", VLLM_FP4_ENV, "fp4", "nvfp4",
+        True, True, VLLM_PINS_FP4,
+    ),
+}
+# Accepted CLI spellings that map onto a canonical precision key.
+_VLLM_PRECISION_ALIASES = {"nvfp4": "fp4"}
 
 
 def _normalize_precision(p: str) -> str:
     p = p.strip().lower()
-    return "fp4" if p in ("fp4", "nvfp4") else p
+    return _VLLM_PRECISION_ALIASES.get(p, p)
+
+
+def _vllm_served_model(cfg: Config, spec: _VllmPrecision) -> str:
+    return cfg.vllm_nvfp4_model if spec.uses_nvfp4_checkpoint else cfg.vllm_model
 
 
 def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
     """Return (effective, skipped) precision legs for the vLLM workload.
 
     Unknown precisions raise (a typo like 'int8' must not silently fall through to
-    a bf16 server with bf16 metadata). fp4 (NVFP4) is gated: it needs a Blackwell
-    GPU *and* a pre-quantized checkpoint (--vllm-nvfp4-model); on any other host, or
-    without the checkpoint, the fp4 leg is skipped (and reported) rather than
-    launched into a guaranteed failure."""
+    a bf16 server with bf16 metadata). A precision is skipped (and reported) rather
+    than launched into a guaranteed failure when its gating isn't met: fp4 (NVFP4)
+    needs a Blackwell GPU *and* a pre-quantized checkpoint (--vllm-nvfp4-model)."""
     blackwell = is_blackwell(cfg.gpus[0] if cfg.gpus else "")
     effective: List[str] = []
     skipped: List[str] = []
@@ -321,12 +345,17 @@ def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
         if not raw.strip():
             continue
         p = _normalize_precision(raw)
-        if p not in VLLM_KNOWN_PRECISIONS:
+        spec = _VLLM_PRECISIONS.get(p)
+        if spec is None:
             raise SystemExit(
                 f"Unknown --vllm-precisions value '{raw.strip()}'. "
-                f"Choose from: {', '.join(VLLM_KNOWN_PRECISIONS)} (or nvfp4)."
+                f"Choose from: {', '.join(_VLLM_PRECISIONS)} "
+                f"(aliases: {', '.join(_VLLM_PRECISION_ALIASES)})."
             )
-        if p == "fp4" and not (blackwell and cfg.vllm_nvfp4_model):
+        gated = (spec.requires_blackwell and not blackwell) or (
+            spec.uses_nvfp4_checkpoint and not cfg.vllm_nvfp4_model
+        )
+        if gated:
             if p not in skipped:
                 skipped.append(p)
             continue
@@ -335,24 +364,15 @@ def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
     return effective, skipped
 
 
-def _vllm_precision_spec(cfg: Config, precision: str):
-    """Map a precision leg to (served_model, serve_quant_flag, env_prefix,
-    compute_precision, quantization_metadata)."""
-    if precision == "fp4":
-        return (cfg.vllm_nvfp4_model, " --quantization modelopt_fp4",
-                VLLM_FP4_ENV, "fp4", "nvfp4")
-    if precision == "fp8":
-        return (cfg.vllm_model, " --quantization fp8", "", "fp8", "fp8")
-    # bf16 / baseline: native half precision, no quant flag.
-    return (cfg.vllm_model, "", "", "bf16", "none")
-
-
 def _vllm_leg(cfg: Config, precision: str) -> List[str]:
     """Lines that serve one precision, benchmark it over openai-compatible, publish
     its own per-precision CSV, and tear the server down before the next leg."""
-    model, quant_serve, env, compute_precision, quant_meta = _vllm_precision_spec(
-        cfg, precision
-    )
+    spec = _VLLM_PRECISIONS[precision]
+    model = _vllm_served_model(cfg, spec)
+    quant_serve = spec.serve_quant_flag
+    env = spec.env_prefix
+    compute_precision = spec.compute_precision
+    quant_meta = spec.quantization
     # Record the real GPU as the accelerator (the precision is already carried in
     # --compute-precision/--quantization); a "vllm-fp8" label would overwrite the
     # hardware field and lose which GPU produced the numbers.
@@ -406,7 +426,10 @@ def _vllm_block(cfg: Config) -> str:
     cache and the quantization kernels; SAIB drives the HTTP API and publishes each
     precision as its own comparable result (served_by=vllm)."""
     effective, skipped = resolve_vllm_precisions(cfg)
-    pins = VLLM_PINS_FP4 if "fp4" in effective else VLLM_PINS
+    # Install the strictest pin set any effective leg needs (fp4 raises the floor).
+    pins = VLLM_PINS
+    if any(_VLLM_PRECISIONS[p].pins == VLLM_PINS_FP4 for p in effective):
+        pins = VLLM_PINS_FP4
     lines = [
         'echo "== [vllm] installing vLLM =="',
         f"pip install {pins} || echo 'WARN vllm install failed'",

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -255,46 +255,51 @@ cleanup() {
 trap cleanup EXIT"""
 
 
-def _pt_block(cfg: Config) -> str:
-    args = f" {cfg.pt_args}" if cfg.pt_args else ""
-    publish_args = (
+def _publish_args(cfg: Config) -> str:
+    """Inline publish flags for a saib-* benchmark command (empty when --no-publish)."""
+    return (
         ' --publish-each --non-interactive --database-url "${URL}"'
         if cfg.publish
         else ""
     )
+
+
+def _register_publish_lines(csv: str, pub_tool: str, label: str) -> List[str]:
+    """register-then-publish a results CSV. Register must precede publish so the
+    server accepts rows whose profile isn't registered yet. Shared by every block
+    (pt/llm/vllm) so the publish protocol lives in exactly one place."""
+    return [
+        f'saib-register {csv} -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
+        f'--database-url "${{URL}}" --non-interactive || echo "WARN register {label}"',
+        f'{pub_tool} {csv} -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
+        f'--database-url "${{URL}}" --non-interactive || echo "WARN pub {label}"',
+    ]
+
+
+def _cli_block(cfg: Config, *, label: str, command: str, timeout_var: str,
+               csv: str, pub_tool: str) -> str:
+    """Run a saib-* benchmark CLI under a timeout, then optionally register+publish
+    its CSV. The pt and llm workloads are the same shape modulo command/CSV/tool."""
     lines = [
-        'echo "== [pt] running (timeout ${PT_TIMEOUT}s) =="',
-        f'timeout -k 60 "${{PT_TIMEOUT}}" saib-pt{args}{publish_args} || echo "WARN saib-pt rc=$?"',
+        f'echo "== [{label}] running (timeout ${{{timeout_var}}}s) =="',
+        f'timeout -k 60 "${{{timeout_var}}}" {command}{_publish_args(cfg)} '
+        f'|| echo "WARN {command.split()[0]} rc=$?"',
     ]
     if cfg.publish:
-        lines += [
-            'saib-register results_pt.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN register pt"',
-            'saib-pub results_pt.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN pub pt"',
-        ]
+        lines += _register_publish_lines(csv, pub_tool, label)
     return "\n".join(lines)
+
+
+def _pt_block(cfg: Config) -> str:
+    command = "saib-pt" + (f" {cfg.pt_args}" if cfg.pt_args else "")
+    return _cli_block(cfg, label="pt", command=command, timeout_var="PT_TIMEOUT",
+                      csv="results_pt.csv", pub_tool="saib-pub")
 
 
 def _llm_block(cfg: Config) -> str:
-    args = f" {cfg.llm_args}" if cfg.llm_args else ""
-    publish_args = (
-        ' --publish-each --non-interactive --database-url "${URL}"'
-        if cfg.publish
-        else ""
-    )
-    lines = [
-        'echo "== [llm] running (timeout ${LLM_TIMEOUT}s) =="',
-        f'timeout -k 60 "${{LLM_TIMEOUT}}" saib-llm{args}{publish_args} || echo "WARN saib-llm rc=$?"',
-    ]
-    if cfg.publish:
-        lines += [
-            'saib-register llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN register llm"',
-            'saib-pub-llm llm_results.csv -t "${AI_BENCHMARK_DATABASE_TOKEN}" '
-            '--database-url "${URL}" --non-interactive || echo "WARN pub llm"',
-        ]
-    return "\n".join(lines)
+    command = "saib-llm" + (f" {cfg.llm_args}" if cfg.llm_args else "")
+    return _cli_block(cfg, label="llm", command=command, timeout_var="LLM_TIMEOUT",
+                      csv="llm_results.csv", pub_tool="saib-pub-llm")
 
 
 @dataclass(frozen=True)
@@ -411,12 +416,9 @@ def _vllm_leg(cfg: Config, precision: str) -> List[str]:
         'wait "$VLLM_PID" 2>/dev/null || true',
     ]
     if cfg.publish:
-        lines += [
-            f'saib-register {out_base}.csv -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
-            f'--database-url "${{URL}}" --non-interactive || echo "WARN register vllm[{precision}]"',
-            f'saib-pub-llm {out_base}.csv -t "${{AI_BENCHMARK_DATABASE_TOKEN}}" '
-            f'--database-url "${{URL}}" --non-interactive || echo "WARN pub vllm[{precision}]"',
-        ]
+        lines += _register_publish_lines(
+            f"{out_base}.csv", "saib-pub-llm", f"vllm[{precision}]"
+        )
     return lines
 
 

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -297,6 +297,10 @@ def _llm_block(cfg: Config) -> str:
     return "\n".join(lines)
 
 
+# Precisions the vLLM workload knows how to serve (after alias normalization).
+VLLM_KNOWN_PRECISIONS = ("bf16", "fp8", "fp4")
+
+
 def _normalize_precision(p: str) -> str:
     p = p.strip().lower()
     return "fp4" if p in ("fp4", "nvfp4") else p
@@ -305,9 +309,11 @@ def _normalize_precision(p: str) -> str:
 def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
     """Return (effective, skipped) precision legs for the vLLM workload.
 
-    fp4 (NVFP4) is gated: it needs a Blackwell GPU *and* a pre-quantized checkpoint
-    (--vllm-nvfp4-model). On any other host, or without the checkpoint, the fp4 leg
-    is skipped (and reported) rather than launched into a guaranteed failure."""
+    Unknown precisions raise (a typo like 'int8' must not silently fall through to
+    a bf16 server with bf16 metadata). fp4 (NVFP4) is gated: it needs a Blackwell
+    GPU *and* a pre-quantized checkpoint (--vllm-nvfp4-model); on any other host, or
+    without the checkpoint, the fp4 leg is skipped (and reported) rather than
+    launched into a guaranteed failure."""
     blackwell = is_blackwell(cfg.gpus[0] if cfg.gpus else "")
     effective: List[str] = []
     skipped: List[str] = []
@@ -315,6 +321,11 @@ def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
         if not raw.strip():
             continue
         p = _normalize_precision(raw)
+        if p not in VLLM_KNOWN_PRECISIONS:
+            raise SystemExit(
+                f"Unknown --vllm-precisions value '{raw.strip()}'. "
+                f"Choose from: {', '.join(VLLM_KNOWN_PRECISIONS)} (or nvfp4)."
+            )
         if p == "fp4" and not (blackwell and cfg.vllm_nvfp4_model):
             if p not in skipped:
                 skipped.append(p)

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -450,9 +450,6 @@ def build_container_script(cfg: Config) -> str:
     """The bash exec'd by the pod's dockerStartCmd. The DB token is read from the
     pod env (``AI_BENCHMARK_DATABASE_TOKEN``), never interpolated into the text, so
     it is not baked into the script string."""
-    pip_requirements = [f'"{cfg.pip_spec}"']
-    pip_index_args = ""
-
     blocks = [
         _THREAD_CAPS,
         _SELF_TERMINATE if not cfg.keep else 'echo "== --keep: pod will NOT self-terminate =="',
@@ -461,7 +458,7 @@ def build_container_script(cfg: Config) -> str:
         f'LLM_TIMEOUT="{cfg.llm_timeout}"',
         'echo "== installing SAIB =="',
         "python -m pip install --upgrade pip",
-        f"pip install{pip_index_args} {' '.join(pip_requirements)}",
+        f'pip install "{cfg.pip_spec}"',
     ]
     if cfg.workload in ("pt", "both"):
         blocks.append(_pt_block(cfg))

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -326,22 +326,26 @@ def resolve_vllm_precisions(cfg: Config) -> Tuple[List[str], List[str]]:
 
 def _vllm_precision_spec(cfg: Config, precision: str):
     """Map a precision leg to (served_model, serve_quant_flag, env_prefix,
-    compute_precision, quantization_metadata, accelerator_label)."""
+    compute_precision, quantization_metadata)."""
     if precision == "fp4":
         return (cfg.vllm_nvfp4_model, " --quantization modelopt_fp4",
-                VLLM_FP4_ENV, "fp4", "nvfp4", "vllm-fp4")
+                VLLM_FP4_ENV, "fp4", "nvfp4")
     if precision == "fp8":
-        return (cfg.vllm_model, " --quantization fp8", "", "fp8", "fp8", "vllm-fp8")
+        return (cfg.vllm_model, " --quantization fp8", "", "fp8", "fp8")
     # bf16 / baseline: native half precision, no quant flag.
-    return (cfg.vllm_model, "", "", "bf16", "none", "vllm-bf16")
+    return (cfg.vllm_model, "", "", "bf16", "none")
 
 
 def _vllm_leg(cfg: Config, precision: str) -> List[str]:
     """Lines that serve one precision, benchmark it over openai-compatible, publish
     its own per-precision CSV, and tear the server down before the next leg."""
-    model, quant_serve, env, compute_precision, quant_meta, accel = _vllm_precision_spec(
+    model, quant_serve, env, compute_precision, quant_meta = _vllm_precision_spec(
         cfg, precision
     )
+    # Record the real GPU as the accelerator (the precision is already carried in
+    # --compute-precision/--quantization); a "vllm-fp8" label would overwrite the
+    # hardware field and lose which GPU produced the numbers.
+    accel = cfg.gpus[0] if cfg.gpus else "vllm"
     base = f"http://localhost:{VLLM_PORT}"
     out_base = f"llm_results_vllm_{precision}"
     log_file = f"/workspace/vllm_{precision}.log"

--- a/simple_ai_benchmarking/llm_database.py
+++ b/simple_ai_benchmarking/llm_database.py
@@ -53,6 +53,7 @@ class LLMBenchmarkData:
     benchmark_runner_id: str
     benchmark_runner_hash: str
     benchmark_payload_hash: str
+    serving_engine: str = ""
 
     def to_dict(self) -> dict:
         return self.__dict__
@@ -128,6 +129,8 @@ def read_csv_and_create_llm_benchmark_dataset(
                     benchmark_runner_id=row["bench_info_benchmark_runner_id"],
                     benchmark_runner_hash=row["bench_info_benchmark_runner_hash"],
                     benchmark_payload_hash=row["bench_info_benchmark_payload_hash"],
+                    # Spec-2.3 identity dimension; absent in pre-2.3 CSVs -> "".
+                    serving_engine=row.get("bench_info_serving_engine", ""),
                 )
             )
 

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -212,6 +212,15 @@ def build_generation_config_from_args(
         default_precision = "BF16" if backend == HF_CAUSAL_BACKEND else "FP32"
         compute_precision = args.compute_precision or default_precision
         quantization = args.quantization or "none"
+        # Local backends apply no quantization (the torchao path was removed), so
+        # accepting --quantization int8/int4 would silently record a precision the
+        # run never used. Reject it instead of publishing mislabeled data.
+        if quantization != "none":
+            raise SystemExit(
+                f"--quantization '{quantization}' is not supported for the local "
+                f"backend '{backend}'. Low-bit quantization is only available via a "
+                "serving engine (e.g. vLLM) over --backend openai-compatible."
+            )
         weight_source = weight_source or "random_weights"
         if accelerator == "unknown":
             if device_name.startswith("cuda") and torch.cuda.is_available():

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.16.0"
+VERSION = "0.16.1"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -523,7 +523,9 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
 
         return GenerationRequestResult(
             prompt_tokens=prompt_tokens,
-            generated_tokens=generated_tokens or self.cfg.generated_tokens,
+            # Report the actual count (0 if the server produced nothing); falling
+            # back to the requested count here would fabricate throughput.
+            generated_tokens=generated_tokens,
             time_to_first_token_s=time_to_first_token_s
             if time_to_first_token_s is not None
             else duration_s,
@@ -583,7 +585,9 @@ class OllamaGeneration(HTTPGenerationWorkload):
 
         return GenerationRequestResult(
             prompt_tokens=prompt_tokens,
-            generated_tokens=generated_tokens or self.cfg.generated_tokens,
+            # Report the actual count (0 if the server produced nothing); falling
+            # back to the requested count here would fabricate throughput.
+            generated_tokens=generated_tokens,
             time_to_first_token_s=time_to_first_token_s
             if time_to_first_token_s is not None
             else duration_s,

--- a/tests/test_llm_generation_cli.py
+++ b/tests/test_llm_generation_cli.py
@@ -153,6 +153,23 @@ def _args(**overrides) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
+def test_local_backend_rejects_quantization():
+    import pytest
+
+    pytest.importorskip("torch")
+    # Low-bit quantization isn't applied locally; passing it must fail fast rather
+    # than silently record a precision the run never used.
+    with pytest.raises(SystemExit, match="quantization"):
+        build_generation_config_from_args(
+            _args(
+                backend=PYTORCH_GENERATION_BACKEND,
+                model="SimpleTransformerLM",
+                quantization="int8",
+                accelerator="unknown",
+            )
+        )
+
+
 def test_build_generation_config_uses_backend_default_base_url(monkeypatch):
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.test")
 

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -166,6 +166,29 @@ def test_openai_compatible_generation_workload_streams_and_counts_tokens():
     assert workload._session.calls[0][1]["headers"]["Authorization"] == "Bearer token"
     assert result.bench_info.backend == OPENAI_COMPATIBLE_BACKEND
     assert result.performance.generated_tokens_per_second > 0
+
+
+def test_openai_compatible_reports_zero_when_server_streams_no_tokens():
+    # Regression: an empty/refused completion (no content deltas, no usage) must
+    # report 0 generated tokens, not fabricate the requested count.
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="test-model",
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=23,
+        )
+    )
+    workload._session = FakeSession(["data: [DONE]"])
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert result.performance.generated_tokens_per_second == 0
     assert 0 < result.performance.time_to_first_token_s <= result.performance.duration_s
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -55,13 +55,13 @@ class TestPublishDatabase(unittest.TestCase):
             "performance_total_tokens_per_second,performance_time_to_first_token_s,bench_info_benchmark_family,"
             "bench_info_benchmark_spec_name,bench_info_benchmark_spec_version,bench_info_benchmark_profile_id,"
             "bench_info_benchmark_profile_hash,bench_info_benchmark_config_hash,bench_info_benchmark_runner_id,"
-            "bench_info_benchmark_runner_hash,bench_info_benchmark_payload_hash\n"
+            "bench_info_benchmark_runner_hash,bench_info_benchmark_payload_hash,bench_info_serving_engine\n"
             "llama.cpp,0.0.1,cuda,3.11.0,Linux,AMD Ryzen,NVIDIA RTX 4090,inference,llama.cpp,Meta-Llama-3-8B,"
             "8000000000,FP16,Q4_K_M,4096,128,256,1,2026-05-11T12:00:00,10,60.0,21.3,42.5,63.8,0.24,"
             "llm,saib_llm_generation,1.0,llm_llama_v1,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,"
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,saib.llm.generation.v1,"
             "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc,"
-            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\n"
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd,vllm\n"
         )
         # Use delete=False and close the handle before reading: Windows does not
         # allow reopening a NamedTemporaryFile by path while its handle is open.
@@ -77,6 +77,8 @@ class TestPublishDatabase(unittest.TestCase):
         self.assertEqual(benchmark_data[0].backend, "llama.cpp")
         self.assertEqual(benchmark_data[0].generated_tokens_per_second, 42.5)
         self.assertEqual(benchmark_data[0].benchmark_spec_name, "saib_llm_generation")
+        # The spec-2.3 serving_engine column reaches the published record.
+        self.assertEqual(benchmark_data[0].serving_engine, "vllm")
 
     def test_cv_reader_keeps_per_row_extra_info(self):
         # Regression: read_csv_and_create_benchmark_dataset must not leak row 0's

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -78,6 +78,45 @@ class TestPublishDatabase(unittest.TestCase):
         self.assertEqual(benchmark_data[0].generated_tokens_per_second, 42.5)
         self.assertEqual(benchmark_data[0].benchmark_spec_name, "saib_llm_generation")
 
+    def test_cv_reader_keeps_per_row_extra_info(self):
+        # Regression: read_csv_and_create_benchmark_dataset must not leak row 0's
+        # ai_framework_extra_info onto later rows (it reassigned the parameter).
+        cols = [
+            "sw_info_ai_framework_name", "sw_info_ai_framework_version",
+            "sw_info_ai_framework_extra_info", "sw_info_python_version",
+            "sw_info_os_version", "hw_info_cpu", "hw_info_accelerator",
+            "bench_info_workload_type", "bench_info_model", "bench_info_compute_precision",
+            "bench_info_batch_size", "bench_info_date", "bench_info_sample_shape",
+            "bench_info_num_parameters", "bench_info_num_classes", "performance_throughput",
+            "bench_info_benchmark_family", "bench_info_benchmark_spec_name",
+            "bench_info_benchmark_spec_version", "bench_info_benchmark_profile_id",
+            "bench_info_benchmark_profile_hash", "bench_info_benchmark_config_hash",
+            "bench_info_benchmark_runner_id", "bench_info_benchmark_runner_hash",
+            "bench_info_benchmark_payload_hash",
+        ]
+
+        def row(extra):
+            return [
+                "PyTorch", "2.4.0", extra, "3.11.0", "Linux", "AMD Ryzen", "GPU",
+                "InferenceWorkload", "ResNet50", "FP16", "32", "2026-05-11T12:00:00",
+                "224x224x3", "25500000", "1000", "123.4",
+                "cv", "saib_cv_classification", "2.1", "cv_resnet_v2",
+                "h" * 64, "h" * 64, "saib.cv.classification.v2", "r" * 64, "p" * 64,
+            ]
+
+        content = ",".join(cols) + "\n"
+        content += ",".join(row("cuda:0")) + "\n"
+        content += ",".join(row("cpu")) + "\n"
+        csv_path = _write_csv(content)
+        try:
+            data = read_csv_and_create_benchmark_dataset(csv_path)
+        finally:
+            os.remove(csv_path)
+
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0].ai_framework_extra_info, "cuda:0")
+        self.assertEqual(data[1].ai_framework_extra_info, "cpu")
+
     def test_cv_reader_rejects_llm_csv_with_clear_error(self):
         # An LLM CSV (has bench_info_backend, no bench_info_workload_type).
         csv_path = _write_csv(

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -121,11 +121,12 @@ def test_workload_vllm_runs_bf16_then_fp8_legs_with_correct_metadata():
     # bf16 leg: no quant flag; fp8 leg: --quantization fp8 -- bf16 served first.
     assert f'vllm serve "{VLLM_DEFAULT_MODEL}" --port' in script  # bf16, no quant
     assert f'vllm serve "{VLLM_DEFAULT_MODEL}" --quantization fp8' in script
-    assert script.index("vllm-bf16") < script.index("vllm-fp8")
-    # Each leg passes the correct metadata to saib-llm (the old Quant=none bug).
+    assert script.index("llm_results_vllm_bf16") < script.index("llm_results_vllm_fp8")
+    # Each leg passes the correct metadata to saib-llm (the old Quant=none bug),
+    # and records the real GPU as the accelerator (not a "vllm-fp8" label).
     assert '--served-by vllm' in script
-    assert '--accelerator "vllm-bf16" --compute-precision bf16 --quantization none' in script
-    assert '--accelerator "vllm-fp8" --compute-precision fp8 --quantization fp8' in script
+    assert '--accelerator "NVIDIA B200" --compute-precision bf16 --quantization none' in script
+    assert '--accelerator "NVIDIA B200" --compute-precision fp8 --quantization fp8' in script
     assert script.index("/health") < script.index("saib-llm --backend openai-compatible")
     assert '--base-url "http://localhost:8000"' in script
     # Standalone: no pt/llm default benchmarks; ends with the done marker.
@@ -155,7 +156,7 @@ def test_workload_vllm_fp4_gated_to_blackwell_with_checkpoint():
     assert script.count("vllm serve") == 3
     assert 'vllm serve "nvidia/ckpt-nvfp4" --quantization modelopt_fp4' in script
     assert "FLASHINFER_FORCE_SM=120f" in script
-    assert '--accelerator "vllm-fp4" --compute-precision fp4 --quantization nvfp4' in script
+    assert '--accelerator "NVIDIA B200" --compute-precision fp4 --quantization nvfp4' in script
     assert '"vllm>=0.13.0"' in script  # fp4 raises the vLLM floor
 
     # Non-Blackwell, or no checkpoint: fp4 is skipped, not launched.

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -171,6 +171,17 @@ def test_workload_vllm_fp4_gated_to_blackwell_with_checkpoint():
     assert '"vllm==0.11.0"' in ada_script  # no fp4 -> the 0.11 pin
 
 
+def test_workload_vllm_rejects_unknown_precision():
+    import pytest
+
+    cfg = _config(
+        ["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm",
+         "--vllm-precisions", "bf16,int8"]
+    )
+    with pytest.raises(SystemExit, match="Unknown --vllm-precisions"):
+        build_container_script(cfg)
+
+
 def test_workload_vllm_publishes_each_precision_register_before_pub():
     cfg = _config(["--dry-run", "--gpu", "NVIDIA B200", "--workload", "vllm"])
     script = build_container_script(cfg)


### PR DESCRIPTION
**Why:** A whole-repo, high-effort code-review pass surfaced several correctness bugs (mostly in the publish + vLLM-runner paths) plus maintainability cleanups. Each is landed as its own commit.

**What (one commit each):**
- **P1** Fix CV publish leaking row 0's `extra_info` onto all rows (`database.py`).
- **P1** Record the real GPU as the accelerator for vLLM legs (was overwritten by a `vllm-fp8` label).
- **P1** Reject `--quantization` on local backends instead of silently recording a precision the run never used.
- **P1** Validate `--vllm-precisions` and reject unknown values (a typo no longer serves bf16 with wrong metadata).
- **P2** Publish `serving_engine` with LLM results (reader + `LLMBenchmarkData` were dropping the spec-2.3 field).
- **P2** Report the actual generated-token count for the HTTP backends (no more fabricating the requested count on an empty completion).
- **P3** Centralize vLLM precision handling in one declarative table.
- **P3** Remove dead `pip_index_args` from `build_container_script`.
- **P3** Dedupe the run/publish scaffold across the pt/llm/vllm blocks.
- Bump version to 0.16.1.

Not changed: the heavier default load (concurrency 8) is intentional and left as-is; config-bundling removal stands (deliberate `hf_transfer` fix).

**Test:** `python3 -m compileall simple_ai_benchmarking tests` + `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q` → 87 passed. Added regression tests: CV per-row extra_info, local-backend quantization rejection, unknown vLLM precision, serving_engine round-trip, HTTP zero-token reporting; updated the vLLM runner tests for the real-GPU accelerator.