### PR TITLE
feat: live console log streaming with reliable failed-run reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setuptools.setup(
             "saib-pub-llm = simple_ai_benchmarking.entrypoints:publish_llm",
             "saib-register = simple_ai_benchmarking.entrypoints:register_profiles",
             "saib-runpod = simple_ai_benchmarking.experimental.runpod_runner:main",
+            "saib-logship = simple_ai_benchmarking.experimental.log_shipper:main",
         ]
     },
 )

--- a/simple_ai_benchmarking/experimental/log_shipper.py
+++ b/simple_ai_benchmarking/experimental/log_shipper.py
@@ -64,10 +64,32 @@ DEFAULT_BATCH_LINES = 500       # lines per POST (server cap is higher)
 DEFAULT_MAX_RUNTIME = 6 * 3600  # hard stop so a forgotten shipper can't run forever
 MAX_PENDING_LINES = 20000       # bound memory if the server is unreachable for long
 POST_TIMEOUT = 15               # seconds per ingest request
+FINAL_FLUSH_RETRIES = 4         # extra attempts to ship the tail before giving up
 
 
 def log(message: str) -> None:
     print(f"[saib-logship {time.strftime('%H:%M:%S')}] {message}", flush=True)
+
+
+def _post_json(url: str, payload: dict, token: Optional[str], label: str) -> bool:
+    """POST ``payload`` as JSON with optional Token auth. Return True on a 2xx.
+
+    Best-effort: every failure mode (HTTP error, timeout, DNS, bad JSON) returns
+    False instead of raising, so the caller simply retries on the next tick."""
+    body = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=POST_TIMEOUT) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as exc:
+        log(f"{label} rejected (HTTP {exc.code}); will retry")
+        return False
+    except Exception as exc:  # noqa: BLE001 -- side-car must never crash the run
+        log(f"{label} failed ({exc.__class__.__name__}); will retry")
+        return False
 
 
 def post_lines(
@@ -77,25 +99,10 @@ def post_lines(
     token: Optional[str],
     stream: str = "stdout",
 ) -> bool:
-    """POST a batch of lines to the ingest endpoint. Return True on a 2xx.
-
-    Best-effort: every failure mode (HTTP error, timeout, DNS, bad JSON) returns
-    False instead of raising, so the caller simply retries on the next tick."""
+    """POST a batch of lines to the ingest endpoint. Return True on a 2xx."""
     url = database_url.rstrip("/") + LOGS_ENDPOINT
-    body = json.dumps({"run_id": run_id, "stream": stream, "lines": lines}).encode()
-    headers = {"Content-Type": "application/json"}
-    if token:
-        headers["Authorization"] = f"Token {token}"
-    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=POST_TIMEOUT) as resp:
-            return 200 <= resp.status < 300
-    except urllib.error.HTTPError as exc:
-        log(f"ingest rejected (HTTP {exc.code}); will retry")
-        return False
-    except Exception as exc:  # noqa: BLE001 -- side-car must never crash the run
-        log(f"ingest failed ({exc.__class__.__name__}); will retry")
-        return False
+    payload = {"run_id": run_id, "stream": stream, "lines": lines}
+    return _post_json(url, payload, token, "ingest")
 
 
 def post_run_report(
@@ -105,17 +112,8 @@ def post_run_report(
     ``post_lines`` -- used to make the run appear (and finish) in the dashboard's
     run table, separate from the streamed console lines."""
     url = database_url.rstrip("/") + REPORT_ENDPOINT
-    body = json.dumps({k: v for k, v in fields.items() if v not in (None, "")}).encode()
-    headers = {"Content-Type": "application/json"}
-    if token:
-        headers["Authorization"] = f"Token {token}"
-    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=POST_TIMEOUT) as resp:
-            return 200 <= resp.status < 300
-    except Exception as exc:  # noqa: BLE001
-        log(f"run report failed ({exc.__class__.__name__})")
-        return False
+    payload = {k: v for k, v in fields.items() if v not in (None, "")}
+    return _post_json(url, payload, token, "run report")
 
 
 def _terminal_status_from_stop_file(stop_file: Optional[str]) -> str:
@@ -231,6 +229,21 @@ class LogShipper:
         self._enqueue(self._split_complete_lines(text, final=final))
         self._flush_pending()
 
+    def _final_flush(self) -> None:
+        """Last drain at end of run: capture anything written after the stop, then
+        retry shipping the tail a few times. Unlike a normal tick (which just waits
+        for the next pass), this is the last chance to deliver those lines, so a
+        transient blip on the final batch must not silently drop the end of the
+        console."""
+        self.poll_once(final=True)
+        for _ in range(FINAL_FLUSH_RETRIES):
+            if not self._pending:
+                return
+            time.sleep(self.interval)
+            self._flush_pending()
+        if self._pending:
+            log(f"{len(self._pending)} line(s) undelivered at exit")
+
     def _should_stop(self) -> bool:
         return bool(self.stop_file) and os.path.exists(self.stop_file)
 
@@ -263,12 +276,12 @@ class LogShipper:
             self.poll_once()
             if self._should_stop():
                 # Final drain: capture anything written after the stop file.
-                self.poll_once(final=True)
+                self._final_flush()
                 self._report(_terminal_status_from_stop_file(self.stop_file))
                 log("stop file present; final flush done, exiting")
                 return 0
             if time.time() >= deadline:
-                self.poll_once(final=True)
+                self._final_flush()
                 self._report("failed")
                 log("max runtime reached; exiting")
                 return 0

--- a/simple_ai_benchmarking/experimental/log_shipper.py
+++ b/simple_ai_benchmarking/experimental/log_shipper.py
@@ -1,0 +1,342 @@
+# Project Name: simple-ai-benchmarking
+# File Name: log_shipper.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Stream a growing log file to the AI Benchmark Database for live debugging.
+
+This is the client half of the dashboard's log-streaming feature. A remote
+benchmark host (typically a RunPod pod launched with ``saib-runpod --debug``)
+tees its whole console output to a file and runs ``saib-logship`` against it in
+the background. The shipper tails the file and POSTs new lines to the
+authenticated ingest endpoint (``/dashboard/api/runs/logs/``), keyed by the
+run's ``run_id``, so the lines show up on the dashboard's live console.
+
+Design goals, in order:
+
+* **Never disturb the benchmark.** Shipping is strictly best-effort: any network
+  or server error is swallowed and retried on the next tick. The shipper is a
+  side-car, not part of the measured workload.
+* **No heavy deps.** Like ``runpod_runner``, this uses stdlib ``urllib`` only, so
+  it works even in the torch-free vLLM pod image without pulling ``requests``.
+* **Lossless ordering.** Only complete lines are shipped (a half-written final
+  line is carried to the next tick); a final drain flushes whatever remains when
+  a stop file appears or the runtime cap is hit.
+
+Usage on the pod::
+
+    saib-logship /workspace/run.log --run-id "$RUNPOD_POD_ID" \\
+        --database-url "$URL" --token "$AI_BENCHMARK_DATABASE_TOKEN" \\
+        --stop-file /workspace/run.done &
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+DEFAULT_DATABASE_URL = "https://timoillusion.pythonanywhere.com"
+LOGS_ENDPOINT = "/dashboard/api/runs/logs/"
+REPORT_ENDPOINT = "/dashboard/api/runs/report/"
+
+DEFAULT_INTERVAL = 3.0          # seconds between tail passes
+DEFAULT_BATCH_LINES = 500       # lines per POST (server cap is higher)
+DEFAULT_MAX_RUNTIME = 6 * 3600  # hard stop so a forgotten shipper can't run forever
+MAX_PENDING_LINES = 20000       # bound memory if the server is unreachable for long
+POST_TIMEOUT = 15               # seconds per ingest request
+
+
+def log(message: str) -> None:
+    print(f"[saib-logship {time.strftime('%H:%M:%S')}] {message}", flush=True)
+
+
+def post_lines(
+    database_url: str,
+    run_id: str,
+    lines: List[str],
+    token: Optional[str],
+    stream: str = "stdout",
+) -> bool:
+    """POST a batch of lines to the ingest endpoint. Return True on a 2xx.
+
+    Best-effort: every failure mode (HTTP error, timeout, DNS, bad JSON) returns
+    False instead of raising, so the caller simply retries on the next tick."""
+    url = database_url.rstrip("/") + LOGS_ENDPOINT
+    body = json.dumps({"run_id": run_id, "stream": stream, "lines": lines}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=POST_TIMEOUT) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as exc:
+        log(f"ingest rejected (HTTP {exc.code}); will retry")
+        return False
+    except Exception as exc:  # noqa: BLE001 -- side-car must never crash the run
+        log(f"ingest failed ({exc.__class__.__name__}); will retry")
+        return False
+
+
+def post_run_report(
+    database_url: str, token: Optional[str], fields: dict
+) -> bool:
+    """POST a run status/heartbeat to the report endpoint. Best-effort like
+    ``post_lines`` -- used to make the run appear (and finish) in the dashboard's
+    run table, separate from the streamed console lines."""
+    url = database_url.rstrip("/") + REPORT_ENDPOINT
+    body = json.dumps({k: v for k, v in fields.items() if v not in (None, "")}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=POST_TIMEOUT) as resp:
+            return 200 <= resp.status < 300
+    except Exception as exc:  # noqa: BLE001
+        log(f"run report failed ({exc.__class__.__name__})")
+        return False
+
+
+def _terminal_status_from_stop_file(stop_file: Optional[str]) -> str:
+    """Map an optional stop-file body to a terminal run status. The launcher
+    writes the benchmark's exit code into the stop file; ``0``/``ok``/empty means
+    success, anything else means the run failed."""
+    if not stop_file:
+        return "completed"
+    try:
+        with open(stop_file, "r", encoding="utf-8", errors="replace") as handle:
+            marker = handle.read().strip()
+    except OSError:
+        return "completed"
+    if marker in ("", "0", "ok", "OK"):
+        return "completed"
+    return "failed"
+
+
+@dataclass
+class LogShipper:
+    """Tails ``path`` and ships new lines to the database, keyed by ``run_id``."""
+
+    path: str
+    run_id: str
+    database_url: str = DEFAULT_DATABASE_URL
+    token: Optional[str] = None
+    stream: str = "stdout"
+    stop_file: Optional[str] = None
+    interval: float = DEFAULT_INTERVAL
+    batch_lines: int = DEFAULT_BATCH_LINES
+    max_runtime: float = DEFAULT_MAX_RUNTIME
+
+    # Optional run-table reporting (separate from streamed console lines).
+    report: bool = False
+    provider: str = ""
+    host: str = ""
+    accelerator: str = ""
+    benchmark_family: str = ""
+    benchmark_name: str = ""
+    runner_name: str = ""
+
+    _offset: int = field(default=0, init=False)
+    _carry: str = field(default="", init=False)
+    _pending: List[str] = field(default_factory=list, init=False)
+
+    def _read_new_text(self) -> str:
+        """Return file bytes appended since the last read, advancing the offset.
+
+        Handles the file not existing yet (returns "") and truncation/rotation
+        (offset past EOF -> restart from the top)."""
+        try:
+            size = os.path.getsize(self.path)
+        except OSError:
+            return ""
+        if size < self._offset:
+            # File shrank (truncated/rotated): start over from the beginning.
+            self._offset = 0
+            self._carry = ""
+        if size == self._offset:
+            return ""
+        try:
+            with open(self.path, "rb") as handle:
+                handle.seek(self._offset)
+                chunk = handle.read()
+        except OSError:
+            return ""
+        self._offset += len(chunk)
+        return chunk.decode("utf-8", errors="replace")
+
+    def _split_complete_lines(self, text: str, *, final: bool) -> List[str]:
+        """Turn newly read text into complete lines.
+
+        A trailing fragment without a newline is held in ``_carry`` until the
+        rest of the line arrives -- unless ``final`` is set, in which case any
+        leftover fragment is flushed too (end-of-run with no trailing newline)."""
+        combined = self._carry + text
+        if not combined:
+            return []
+        parts = combined.split("\n")
+        if final:
+            self._carry = ""
+            # Drop a trailing "" produced by a final newline, keep real content.
+            if parts and parts[-1] == "":
+                parts = parts[:-1]
+            return parts
+        self._carry = parts[-1]
+        return parts[:-1]
+
+    def _enqueue(self, lines: List[str]) -> None:
+        if not lines:
+            return
+        self._pending.extend(lines)
+        # Bound memory if the server has been unreachable: keep the newest lines.
+        if len(self._pending) > MAX_PENDING_LINES:
+            dropped = len(self._pending) - MAX_PENDING_LINES
+            self._pending = self._pending[-MAX_PENDING_LINES:]
+            log(f"dropping {dropped} oldest buffered lines (server unreachable)")
+
+    def _flush_pending(self) -> None:
+        """Ship buffered lines in batches; stop on the first failed batch so the
+        unsent remainder is retried (in order) on the next tick."""
+        while self._pending:
+            batch = self._pending[: self.batch_lines]
+            if not post_lines(
+                self.database_url, self.run_id, batch, self.token, self.stream
+            ):
+                return
+            del self._pending[: len(batch)]
+
+    def poll_once(self, *, final: bool = False) -> None:
+        """One tail pass: read new text, queue complete lines, flush to server."""
+        text = self._read_new_text()
+        self._enqueue(self._split_complete_lines(text, final=final))
+        self._flush_pending()
+
+    def _should_stop(self) -> bool:
+        return bool(self.stop_file) and os.path.exists(self.stop_file)
+
+    def _report(self, status: str) -> None:
+        if not self.report:
+            return
+        post_run_report(
+            self.database_url,
+            self.token,
+            {
+                "run_id": self.run_id,
+                "status": status,
+                "provider": self.provider,
+                "host": self.host,
+                "accelerator": self.accelerator,
+                "benchmark_family": self.benchmark_family,
+                "benchmark_name": self.benchmark_name,
+                "runner_name": self.runner_name,
+            },
+        )
+
+    def run(self) -> int:
+        log(
+            f"shipping '{self.path}' -> {self.database_url}{LOGS_ENDPOINT} "
+            f"(run_id={self.run_id})"
+        )
+        self._report("running")
+        deadline = time.time() + self.max_runtime
+        while True:
+            self.poll_once()
+            if self._should_stop():
+                # Final drain: capture anything written after the stop file.
+                self.poll_once(final=True)
+                self._report(_terminal_status_from_stop_file(self.stop_file))
+                log("stop file present; final flush done, exiting")
+                return 0
+            if time.time() >= deadline:
+                self.poll_once(final=True)
+                self._report("failed")
+                log("max runtime reached; exiting")
+                return 0
+            time.sleep(self.interval)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Tail a log file and stream new lines to the AI Benchmark "
+        "Database dashboard for live debugging."
+    )
+    parser.add_argument("logfile", help="Path to the growing log file to tail.")
+    parser.add_argument("--run-id", required=True, help="Run identifier (keys the dashboard console).")
+    parser.add_argument("--database-url", default=DEFAULT_DATABASE_URL)
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("AI_BENCHMARK_DATABASE_TOKEN"),
+        help="Database API token (default: $AI_BENCHMARK_DATABASE_TOKEN).",
+    )
+    parser.add_argument("--stream", default="stdout", choices=["stdout", "stderr", "system"])
+    parser.add_argument(
+        "--stop-file", default=None,
+        help="Exit (after a final flush) once this file exists.",
+    )
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL)
+    parser.add_argument("--batch-lines", type=int, default=DEFAULT_BATCH_LINES)
+    parser.add_argument("--max-runtime", type=float, default=DEFAULT_MAX_RUNTIME)
+    parser.add_argument(
+        "--report", action="store_true",
+        help="Also report run status (running -> completed/failed) to the run table.",
+    )
+    parser.add_argument("--provider", default="")
+    parser.add_argument("--host", default="")
+    parser.add_argument("--accelerator", default="")
+    parser.add_argument("--benchmark-family", default="")
+    parser.add_argument("--benchmark-name", default="")
+    parser.add_argument("--runner-name", default="")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    if not args.token:
+        log("WARNING: no token provided; ingest will be rejected (401). Continuing best-effort.")
+    shipper = LogShipper(
+        path=args.logfile,
+        run_id=args.run_id,
+        database_url=args.database_url,
+        token=args.token,
+        stream=args.stream,
+        stop_file=args.stop_file,
+        interval=args.interval,
+        batch_lines=args.batch_lines,
+        max_runtime=args.max_runtime,
+        report=args.report,
+        provider=args.provider,
+        host=args.host,
+        accelerator=args.accelerator,
+        benchmark_family=args.benchmark_family,
+        benchmark_name=args.benchmark_name,
+        runner_name=args.runner_name,
+    )
+    try:
+        return shipper.run()
+    except KeyboardInterrupt:
+        shipper.poll_once(final=True)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -39,6 +39,12 @@ Usage::
     export AI_BENCHMARK_DATABASE_TOKEN=...     # database API token
     saib-runpod --gpu "NVIDIA GeForce RTX 4090"          # CV + LLM, auto image
     saib-runpod --gpu "NVIDIA B200" --workload llm        # Blackwell image, auto
+    saib-runpod --gpu "NVIDIA B200" --workload vllm --debug   # stream live console
+
+With ``--debug`` the pod tees its whole stdout/stderr to a file and a background
+``saib-logship`` streams it to the database dashboard's live console
+(``/dashboard/runs/<run_id>/``) for real-time monitoring -- the run also appears
+in the dashboard run table. The console URL is printed when the pod is created.
 
 Dry run (no API key needed, prints the plan and the exact container script)::
 
@@ -146,6 +152,13 @@ VLLM_SAIB_SPEC = (
 
 DONE_MARKER = "SAIB_ALL_DONE"
 
+# --debug live-log streaming. The whole container console (install + benchmark)
+# is teed to RUN_LOG_FILE; a background `saib-logship` tails it to the dashboard
+# and stops once RUN_STOP_FILE appears (written right before self-termination, so
+# the shipper gets a final flush before the pod is torn down).
+RUN_LOG_FILE = "/workspace/saib_run.log"
+RUN_STOP_FILE = "/workspace/saib_run.done"
+
 
 def log(message: str) -> None:
     print(f"[saib-runpod {time.strftime('%H:%M:%S')}] {message}", flush=True)
@@ -182,6 +195,8 @@ class Config:
     capacity_wait: int
     pt_timeout: int
     llm_timeout: int
+    debug: bool
+    run_id: str
     image_was_set: bool = False
     pip_was_set: bool = False
     llm_args_was_set: bool = False
@@ -253,6 +268,61 @@ cleanup() {
   sleep 900
 }
 trap cleanup EXIT"""
+
+
+def _run_id_expr(cfg: Config) -> str:
+    """Shell expression for the run id: an explicit --run-id wins, else the pod's
+    own id (unique per pod, and what the saib-runpod caller is told to watch)."""
+    return cfg.run_id if cfg.run_id else "${RUNPOD_POD_ID}"
+
+
+def _debug_header(cfg: Config) -> str:
+    """Tee the entire container console to a file so the log shipper can stream it.
+
+    Placed first (before any other block) so install output is captured too; the
+    shipper itself starts later, once SAIB is installed, and ships the backlog."""
+    return "\n".join(
+        [
+            f'RUN_LOG_FILE="{RUN_LOG_FILE}"',
+            f'RUN_STOP_FILE="{RUN_STOP_FILE}"',
+            f'RUN_ID="{_run_id_expr(cfg)}"',
+            'mkdir -p "$(dirname "$RUN_LOG_FILE")" 2>/dev/null || true',
+            # Capture stdout AND stderr for everything that follows.
+            'exec > >(tee -a "$RUN_LOG_FILE") 2>&1',
+            'echo "== [debug] live console streaming for run ${RUN_ID} =="',
+        ]
+    )
+
+
+def _debug_shipper_launch(cfg: Config) -> str:
+    """Start saib-logship in the background once SAIB is installed. Its own output
+    goes to /tmp (NOT the teed file) so it does not ship its own chatter in a loop.
+    The DB token is read from the pod env, never placed on the command line."""
+    accel = cfg.gpus[0] if cfg.gpus else ""
+    return "\n".join(
+        [
+            'echo "== [debug] starting log shipper =="',
+            # Backgrounded (& cannot be followed by ||); if saib-logship is missing
+            # the subshell just exits and streaming is silently skipped -- the run
+            # itself is never blocked by the side-car.
+            f'( saib-logship "$RUN_LOG_FILE" --run-id "$RUN_ID" --database-url "$URL" '
+            f'--stop-file "$RUN_STOP_FILE" --report --provider runpod '
+            f'--host "${{RUNPOD_POD_ID}}" --accelerator "{accel}" '
+            f'--benchmark-family "{cfg.workload}" '
+            f'>/tmp/saib_logship.log 2>&1 || echo "WARN log shipper exited" ) &',
+        ]
+    )
+
+
+def _debug_footer() -> str:
+    """Signal the shipper that the run is done and give it one interval to flush
+    the tail before the self-terminate trap deletes the pod."""
+    return "\n".join(
+        [
+            'echo "ok" > "$RUN_STOP_FILE"',
+            'sleep 10',
+        ]
+    )
 
 
 def _publish_args(cfg: Config) -> str:
@@ -452,7 +522,11 @@ def build_container_script(cfg: Config) -> str:
     """The bash exec'd by the pod's dockerStartCmd. The DB token is read from the
     pod env (``AI_BENCHMARK_DATABASE_TOKEN``), never interpolated into the text, so
     it is not baked into the script string."""
-    blocks = [
+    blocks = []
+    if cfg.debug:
+        # Must precede everything so install output is teed too.
+        blocks.append(_debug_header(cfg))
+    blocks += [
         _THREAD_CAPS,
         _SELF_TERMINATE if not cfg.keep else 'echo "== --keep: pod will NOT self-terminate =="',
         f'URL="{cfg.database_url}"',
@@ -462,6 +536,9 @@ def build_container_script(cfg: Config) -> str:
         "python -m pip install --upgrade pip",
         f'pip install "{cfg.pip_spec}"',
     ]
+    if cfg.debug:
+        # SAIB (and thus saib-logship) is installed now; start streaming.
+        blocks.append(_debug_shipper_launch(cfg))
     if cfg.workload in ("pt", "both"):
         blocks.append(_pt_block(cfg))
     if cfg.workload in ("llm", "both"):
@@ -469,6 +546,8 @@ def build_container_script(cfg: Config) -> str:
     if cfg.workload == "vllm":
         blocks.append(_vllm_block(cfg))
     blocks.append(f'echo "{DONE_MARKER}"')
+    if cfg.debug:
+        blocks.append(_debug_footer())
     return "\n".join(blocks)
 
 
@@ -493,7 +572,8 @@ def rest_call(method: str, path: str, key: str, body: Optional[dict] = None) -> 
 
 def build_pod_body(cfg: Config, script: str) -> dict:
     env = {"RUNPOD_API_KEY": cfg.api_key}
-    if cfg.publish:
+    # The DB token is needed to publish results and/or to stream debug logs.
+    if cfg.publish or cfg.debug:
         env["AI_BENCHMARK_DATABASE_TOKEN"] = cfg.db_token or ""
     return {
         "name": f"saib-{cfg.workload}-{int(time.time())}",
@@ -633,6 +713,17 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Do not self-terminate the pod (debugging). You must terminate it yourself!",
     )
     parser.add_argument(
+        "--debug", action="store_true",
+        help="Stream the pod's live console output to the database dashboard for "
+        "real-time debugging (tees stdout/stderr and ships it via saib-logship). "
+        "Needs AI_BENCHMARK_DATABASE_TOKEN even with --no-publish.",
+    )
+    parser.add_argument(
+        "--run-id", default="",
+        help="Run identifier for the dashboard console/run table. Default: the "
+        "pod's own id (resolved on the pod).",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Print the plan and container script, then exit (no API key needed).",
     )
@@ -666,6 +757,8 @@ def build_config(args: argparse.Namespace) -> Config:
         capacity_wait=args.capacity_wait,
         pt_timeout=args.pt_timeout,
         llm_timeout=args.llm_timeout,
+        debug=args.debug,
+        run_id=args.run_id,
         image_was_set=args.image is not None,
         pip_was_set=args.pip_spec is not None,
         llm_args_was_set=args.llm_args is not None,
@@ -700,14 +793,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         cfg.api_key = _prompt_secret("Paste your RunPod API key (RUNPOD_API_KEY)")
     if not cfg.api_key:
         raise SystemExit("RUNPOD_API_KEY is required (env, --api-key, or interactive prompt).")
-    if cfg.publish and not cfg.db_token:
+    needs_token = cfg.publish or cfg.debug
+    if needs_token and not cfg.db_token:
         cfg.db_token = _prompt_secret(
             "Paste your AI Benchmark Database token (AI_BENCHMARK_DATABASE_TOKEN)"
         )
-    if cfg.publish and not cfg.db_token:
+    if needs_token and not cfg.db_token:
         raise SystemExit(
-            "AI_BENCHMARK_DATABASE_TOKEN is required to publish "
-            "(env, --db-token, interactive prompt, or pass --no-publish)."
+            "AI_BENCHMARK_DATABASE_TOKEN is required to publish or stream debug logs "
+            "(env, --db-token, interactive prompt, or drop --debug and pass --no-publish)."
         )
 
     # The token lives in the pod env, so rebuild the body now that it is resolved.
@@ -719,6 +813,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         + ("then self-terminate." if not cfg.keep else "and stay up (--keep).")
     )
     log("Fire-and-forget: nothing connects back to the pod. Monitor it in the RunPod console.")
+    if cfg.debug:
+        run_id = cfg.run_id or pod_id
+        console_url = f"{cfg.database_url.rstrip('/')}/dashboard/runs/{run_id}/"
+        log(f"Live console (debug): {console_url}")
     return 0
 
 

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -286,6 +286,9 @@ def _debug_header(cfg: Config) -> str:
             f'RUN_LOG_FILE="{RUN_LOG_FILE}"',
             f'RUN_STOP_FILE="{RUN_STOP_FILE}"',
             f'RUN_ID="{_run_id_expr(cfg)}"',
+            # Benchmark exit code, set by the workload blocks; the footer writes it
+            # to the stop file so the run is reported completed (0) or failed.
+            "SAIB_RC=0",
             'mkdir -p "$(dirname "$RUN_LOG_FILE")" 2>/dev/null || true',
             # Capture stdout AND stderr for everything that follows.
             'exec > >(tee -a "$RUN_LOG_FILE") 2>&1',
@@ -315,11 +318,12 @@ def _debug_shipper_launch(cfg: Config) -> str:
 
 
 def _debug_footer() -> str:
-    """Signal the shipper that the run is done and give it one interval to flush
-    the tail before the self-terminate trap deletes the pod."""
+    """Signal the shipper that the run is done and give it a moment to flush the
+    tail before the self-terminate trap deletes the pod. The stop file carries the
+    benchmark exit code (SAIB_RC) so the shipper reports completed vs failed."""
     return "\n".join(
         [
-            'echo "ok" > "$RUN_STOP_FILE"',
+            'echo "${SAIB_RC:-0}" > "$RUN_STOP_FILE"',
             'sleep 10',
         ]
     )
@@ -332,6 +336,15 @@ def _publish_args(cfg: Config) -> str:
         if cfg.publish
         else ""
     )
+
+
+def _capture_failure(message: str) -> str:
+    """Trailing shell clause for a benchmark command: on a non-zero exit, warn and
+    record the code in ``SAIB_RC``. The run must keep going (publish + teardown),
+    so the failure is not fatal, but the captured code lets the debug footer write
+    a real pass/fail marker -- otherwise every run looks 'completed'. Publishing
+    failures deliberately do not touch SAIB_RC: run status reflects the benchmark."""
+    return f'|| {{ rc=$?; echo "WARN {message} rc=$rc"; SAIB_RC=$rc; }}'
 
 
 def _register_publish_lines(csv: str, pub_tool: str, label: str) -> List[str]:
@@ -353,7 +366,7 @@ def _cli_block(cfg: Config, *, label: str, command: str, timeout_var: str,
     lines = [
         f'echo "== [{label}] running (timeout ${{{timeout_var}}}s) =="',
         f'timeout -k 60 "${{{timeout_var}}}" {command}{_publish_args(cfg)} '
-        f'|| echo "WARN {command.split()[0]} rc=$?"',
+        f'{_capture_failure(command.split()[0])}',
     ]
     if cfg.publish:
         lines += _register_publish_lines(csv, pub_tool, label)
@@ -480,7 +493,7 @@ def _vllm_leg(cfg: Config, precision: str) -> List[str]:
         f"--quantization {quant_meta} --requests {cfg.vllm_requests} "
         f"--concurrency {cfg.vllm_concurrency} --prompt-tokens {cfg.vllm_prompt_tokens} "
         f"--generated-tokens {cfg.vllm_generated_tokens} --out-file-base {out_base} "
-        f'|| echo "WARN saib-llm vllm[{precision}] rc=$?"',
+        f'{_capture_failure(f"saib-llm vllm[{precision}]")}',
         # Stop the server and wait for the port to free before the next precision.
         'kill "$VLLM_PID" >/dev/null 2>&1 || true',
         'wait "$VLLM_PID" 2>/dev/null || true',

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.16.1"
+VERSION = "0.17.0"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_log_shipper.py
+++ b/tests/test_log_shipper.py
@@ -103,6 +103,27 @@ def test_pending_buffer_is_bounded(tmp_path, monkeypatch):
     assert shipper._pending == ["line7", "line8", "line9"]
 
 
+def test_final_flush_retries_tail_before_giving_up(tmp_path, monkeypatch):
+    shipper, log_file = _shipper(tmp_path)
+    shipper.interval = 0  # no real sleeping between retries
+    # Fail the first two attempts, then succeed: the tail must still be delivered
+    # instead of being dropped on the single final pass.
+    outcomes = [False, False, True]
+    sent = []
+
+    def fake_post(url, rid, lines, token, stream):
+        ok = outcomes.pop(0)
+        if ok:
+            sent.append(list(lines))
+        return ok
+
+    monkeypatch.setattr(ls, "post_lines", fake_post)
+    log_file.write_text("tail line\n")
+    shipper._final_flush()
+    assert shipper._pending == []
+    assert sent == [["tail line"]]
+
+
 # --------------------------------------------------------------------------- #
 # Run lifecycle reporting
 # --------------------------------------------------------------------------- #

--- a/tests/test_log_shipper.py
+++ b/tests/test_log_shipper.py
@@ -1,0 +1,209 @@
+import simple_ai_benchmarking.experimental.log_shipper as ls
+from simple_ai_benchmarking.experimental.log_shipper import (
+    LogShipper,
+    post_lines,
+    post_run_report,
+    _terminal_status_from_stop_file,
+    parse_args,
+)
+
+
+def _shipper(tmp_path, **kw):
+    log_file = tmp_path / "run.log"
+    log_file.write_text("")
+    shipper = LogShipper(path=str(log_file), run_id="r1", token="tok", **kw)
+    return shipper, log_file
+
+
+# --------------------------------------------------------------------------- #
+# Line splitting / carry handling
+# --------------------------------------------------------------------------- #
+def test_complete_lines_only_partial_is_carried(tmp_path):
+    shipper, _ = _shipper(tmp_path)
+    assert shipper._split_complete_lines("hello\nwor", final=False) == ["hello"]
+    # The dangling "wor" is held until the rest of the line arrives.
+    assert shipper._split_complete_lines("ld\n", final=False) == ["world"]
+
+
+def test_final_flush_emits_trailing_fragment(tmp_path):
+    shipper, _ = _shipper(tmp_path)
+    shipper._split_complete_lines("partial line", final=False)
+    assert shipper._split_complete_lines("", final=True) == ["partial line"]
+
+
+def test_final_flush_drops_trailing_empty_after_newline(tmp_path):
+    shipper, _ = _shipper(tmp_path)
+    assert shipper._split_complete_lines("a\nb\n", final=True) == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# Reading a growing file
+# --------------------------------------------------------------------------- #
+def test_read_new_text_advances_offset(tmp_path):
+    shipper, log_file = _shipper(tmp_path)
+    log_file.write_text("line1\n")
+    assert shipper._read_new_text() == "line1\n"
+    # Nothing new yet.
+    assert shipper._read_new_text() == ""
+    log_file.write_text("line1\nline2\n")
+    assert shipper._read_new_text() == "line2\n"
+
+
+def test_read_new_text_handles_truncation(tmp_path):
+    shipper, log_file = _shipper(tmp_path)
+    log_file.write_text("aaaa\nbbbb\n")
+    shipper._read_new_text()
+    # File shrinks (rotated/truncated): offset resets and we re-read from the top.
+    log_file.write_text("x\n")
+    assert shipper._read_new_text() == "x\n"
+
+
+# --------------------------------------------------------------------------- #
+# poll_once: queue + flush + retry semantics
+# --------------------------------------------------------------------------- #
+def test_poll_once_ships_complete_lines(tmp_path, monkeypatch):
+    shipper, log_file = _shipper(tmp_path)
+    sent = []
+    monkeypatch.setattr(
+        ls, "post_lines",
+        lambda url, rid, lines, token, stream: sent.append(list(lines)) or True,
+    )
+    log_file.write_text("a\nb\nhalf")
+    shipper.poll_once()
+    assert sent == [["a", "b"]]
+    # The half line is not shipped until completed / final.
+    assert shipper._pending == []
+
+
+def test_poll_once_keeps_pending_on_failure_then_retries(tmp_path, monkeypatch):
+    shipper, log_file = _shipper(tmp_path)
+    outcomes = [False, True]
+    sent = []
+
+    def fake_post(url, rid, lines, token, stream):
+        sent.append(list(lines))
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(ls, "post_lines", fake_post)
+    log_file.write_text("a\nb\n")
+    shipper.poll_once()           # first attempt fails -> lines stay pending
+    assert shipper._pending == ["a", "b"]
+    shipper.poll_once()           # retries the same lines, succeeds
+    assert shipper._pending == []
+    assert sent == [["a", "b"], ["a", "b"]]
+
+
+def test_pending_buffer_is_bounded(tmp_path, monkeypatch):
+    shipper, log_file = _shipper(tmp_path)
+    monkeypatch.setattr(ls, "post_lines", lambda *a, **k: False)  # always fail
+    monkeypatch.setattr(ls, "MAX_PENDING_LINES", 3)
+    log_file.write_text("".join(f"line{i}\n" for i in range(10)))
+    shipper.poll_once()
+    # Only the newest MAX_PENDING_LINES are retained.
+    assert shipper._pending == ["line7", "line8", "line9"]
+
+
+# --------------------------------------------------------------------------- #
+# Run lifecycle reporting
+# --------------------------------------------------------------------------- #
+def test_run_reports_running_then_completed(tmp_path, monkeypatch):
+    log_file = tmp_path / "run.log"
+    log_file.write_text("done line\n")
+    stop_file = tmp_path / "run.done"
+    stop_file.write_text("ok")  # present from the start -> one pass then stop
+
+    statuses = []
+    monkeypatch.setattr(ls, "post_lines", lambda *a, **k: True)
+    monkeypatch.setattr(
+        ls, "post_run_report",
+        lambda url, token, fields: statuses.append(fields["status"]) or True,
+    )
+    shipper = LogShipper(
+        path=str(log_file), run_id="r1", token="tok",
+        stop_file=str(stop_file), report=True, interval=0,
+    )
+    assert shipper.run() == 0
+    assert statuses == ["running", "completed"]
+
+
+def test_run_without_report_sends_no_status(tmp_path, monkeypatch):
+    log_file = tmp_path / "run.log"
+    log_file.write_text("x\n")
+    stop_file = tmp_path / "run.done"
+    stop_file.write_text("ok")
+    calls = []
+    monkeypatch.setattr(ls, "post_lines", lambda *a, **k: True)
+    monkeypatch.setattr(ls, "post_run_report", lambda *a, **k: calls.append(1) or True)
+    shipper = LogShipper(
+        path=str(log_file), run_id="r1", stop_file=str(stop_file),
+        report=False, interval=0,
+    )
+    shipper.run()
+    assert calls == []
+
+
+def test_terminal_status_from_stop_file(tmp_path):
+    ok = tmp_path / "ok.done"
+    ok.write_text("0")
+    assert _terminal_status_from_stop_file(str(ok)) == "completed"
+
+    bad = tmp_path / "bad.done"
+    bad.write_text("137")
+    assert _terminal_status_from_stop_file(str(bad)) == "failed"
+
+    assert _terminal_status_from_stop_file(None) == "completed"
+    assert _terminal_status_from_stop_file(str(tmp_path / "missing")) == "completed"
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers are best-effort (never raise)
+# --------------------------------------------------------------------------- #
+class _FakeResp:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_post_lines_returns_true_on_2xx(monkeypatch):
+    monkeypatch.setattr(ls.urllib.request, "urlopen", lambda req, timeout=0: _FakeResp(201))
+    assert post_lines("http://db", "r1", ["a"], "tok") is True
+
+
+def test_post_lines_swallows_errors(monkeypatch):
+    def boom(req, timeout=0):
+        raise OSError("network down")
+
+    monkeypatch.setattr(ls.urllib.request, "urlopen", boom)
+    assert post_lines("http://db", "r1", ["a"], "tok") is False
+
+
+def test_post_run_report_omits_empty_fields(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = req.data
+        return _FakeResp(200)
+
+    monkeypatch.setattr(ls.urllib.request, "urlopen", fake_urlopen)
+    ok = post_run_report(
+        "http://db", "tok",
+        {"run_id": "r1", "status": "running", "host": "", "provider": "runpod"},
+    )
+    assert ok is True
+    import json
+
+    body = json.loads(captured["body"])
+    assert "host" not in body  # empty strings are dropped
+    assert body["provider"] == "runpod"
+
+
+def test_parse_args_reads_token_from_env(monkeypatch):
+    monkeypatch.setenv("AI_BENCHMARK_DATABASE_TOKEN", "envtok")
+    args = parse_args(["/tmp/x.log", "--run-id", "r1"])
+    assert args.token == "envtok"
+    assert args.run_id == "r1"

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -299,9 +299,22 @@ def test_debug_injects_tee_shipper_and_footer():
     assert script.index('exec > >(tee -a "$RUN_LOG_FILE")') < script.index("installing SAIB")
     # Shipper starts after SAIB is installed.
     assert script.index("pip install") < script.index("saib-logship")
-    # Footer signals completion so the shipper can flush before teardown.
-    assert 'echo "ok" > "$RUN_STOP_FILE"' in script
+    # Footer writes the benchmark exit code (not a hardcoded "ok") so the shipper
+    # can report completed vs failed; SAIB_RC is seeded in the debug header.
+    assert "SAIB_RC=0" in script
+    assert 'echo "${SAIB_RC:-0}" > "$RUN_STOP_FILE"' in script
     assert script.rstrip().endswith("sleep 10")
+
+
+def test_debug_records_benchmark_failure_in_stop_file_code():
+    # A failing benchmark CLI must set SAIB_RC so the footer reports a real failure
+    # instead of always writing success. The capture clause replaces the old
+    # fire-and-forget `|| echo WARN` that swallowed the exit code.
+    cfg = _config(["--dry-run", "--debug", "--workload", "llm", "--gpu", "NVIDIA RTX A6000"])
+    script = build_container_script(cfg)
+    assert "SAIB_RC=$rc" in script
+    # The swallow-and-forget form must be gone for the benchmark command.
+    assert 'rc=$?"' not in script
 
 
 def test_debug_default_run_id_is_pod_id_expression():

--- a/tests/test_runpod_runner.py
+++ b/tests/test_runpod_runner.py
@@ -280,3 +280,57 @@ def test_prompt_secret_is_noop_without_tty(monkeypatch):
         lambda prompt="": (_ for _ in ()).throw(AssertionError("getpass called")),
     )
     assert runner._prompt_secret("token") == ""
+
+
+# --------------------------------------------------------------------------- #
+# --debug live-log streaming
+# --------------------------------------------------------------------------- #
+def test_debug_off_by_default_adds_no_streaming():
+    script = build_container_script(_config(["--dry-run", "--gpu", "NVIDIA RTX A6000"]))
+    assert "saib-logship" not in script
+    assert "tee -a" not in script
+    assert runner.RUN_STOP_FILE not in script
+
+
+def test_debug_injects_tee_shipper_and_footer():
+    cfg = _config(["--dry-run", "--debug", "--gpu", "NVIDIA RTX A6000"])
+    script = build_container_script(cfg)
+    # Console is teed before anything else so install output is captured too.
+    assert script.index('exec > >(tee -a "$RUN_LOG_FILE")') < script.index("installing SAIB")
+    # Shipper starts after SAIB is installed.
+    assert script.index("pip install") < script.index("saib-logship")
+    # Footer signals completion so the shipper can flush before teardown.
+    assert 'echo "ok" > "$RUN_STOP_FILE"' in script
+    assert script.rstrip().endswith("sleep 10")
+
+
+def test_debug_default_run_id_is_pod_id_expression():
+    script = build_container_script(_config(["--dry-run", "--debug", "--gpu", "NVIDIA RTX A6000"]))
+    assert 'RUN_ID="${RUNPOD_POD_ID}"' in script
+
+
+def test_debug_explicit_run_id_is_used():
+    script = build_container_script(
+        _config(["--dry-run", "--debug", "--run-id", "my-run-7", "--gpu", "NVIDIA RTX A6000"])
+    )
+    assert 'RUN_ID="my-run-7"' in script
+
+
+def test_debug_passes_accelerator_and_family_to_shipper():
+    cfg = _config(["--dry-run", "--debug", "--workload", "vllm", "--gpu", "NVIDIA B200"])
+    script = build_container_script(cfg)
+    assert '--accelerator "NVIDIA B200"' in script
+    assert '--benchmark-family "vllm"' in script
+
+
+def test_debug_token_in_pod_env_even_without_publish():
+    cfg = _config(["--dry-run", "--debug", "--no-publish", "--db-token", "tok",
+                   "--api-key", "key", "--gpu", "NVIDIA RTX A6000"])
+    body = build_pod_body(cfg, "script")
+    assert body["env"]["AI_BENCHMARK_DATABASE_TOKEN"] == "tok"
+
+
+def test_no_token_in_pod_env_without_debug_or_publish():
+    cfg = _config(["--dry-run", "--no-publish", "--api-key", "key", "--gpu", "NVIDIA RTX A6000"])
+    body = build_pod_body(cfg, "script")
+    assert "AI_BENCHMARK_DATABASE_TOKEN" not in body["env"]

--- a/tools/LOCAL_STREAMING.md
+++ b/tools/LOCAL_STREAMING.md
@@ -1,0 +1,58 @@
+# Testing live log streaming locally
+
+Exercise the dashboard's live-console streaming end-to-end on localhost — the
+same path a RunPod pod uses with `saib-runpod --debug`, but with **no RunPod and
+no Docker**. (Docker, to simulate a real pod environment, can be layered on later;
+this setup deliberately stays host-local.)
+
+```
+tools/dummy_workload.py  ->  logfile  ->  saib-logship  ->  local dashboard DB
+                                                   |
+                                  browser live console  +  read-endpoint verify
+```
+
+The pieces:
+
+| Piece | Repo | Role |
+|-------|------|------|
+| `tools/serve_local.sh` | ai-benchmark-database | migrate + mint a token + run the dev server |
+| `tools/dummy_workload.py` | simple-ai-benchmarking | fake benchmark console (stdout/stderr, sleeps) |
+| `saib-logship` | simple-ai-benchmarking | tails the logfile, ships lines to the DB |
+| `tools/local_stream_demo.py` | simple-ai-benchmarking | drives the workload + shipper, then verifies |
+
+## One command (auto-boots the server)
+
+From the `simple-ai-benchmarking` repo, with the DB repo checked out as a sibling:
+
+```bash
+tools/local_stream_demo.py --start-server --db-repo ../ai-benchmark-database
+```
+
+It boots the dashboard, streams a dummy run, prints the streamed console as the
+**server** returns it, and prints `PASS`/`FAIL`. Open the printed
+`/dashboard/runs/<run_id>/` URL while it runs to watch the live tail. Add `--fail`
+to confirm a failed run is reported as `failed`.
+
+## Two terminals (watch a real server)
+
+```bash
+# terminal 1 — ai-benchmark-database:
+tools/serve_local.sh                      # prints AI_BENCHMARK_DATABASE_TOKEN=...
+
+# terminal 2 — simple-ai-benchmarking:
+AI_BENCHMARK_DATABASE_TOKEN=<token> tools/local_stream_demo.py
+```
+
+Then browse to `http://127.0.0.1:8000/dashboard/` (run table, with a "live
+console" link per run) or directly to the printed run URL.
+
+## What this proves
+
+- `saib-logship` tails a growing file and ships only complete lines, in order.
+- The ingest endpoint stores them and the read endpoint serves them by cursor
+  (the same polling the browser console uses).
+- Run lifecycle is reported (`running` → `completed`/`failed`).
+
+The dummy workload merges stderr into stdout just like the pod's
+`exec > >(tee …) 2>&1`, so the streamed console matches what `--debug` produces
+on a real pod.

--- a/tools/dummy_workload.py
+++ b/tools/dummy_workload.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Project Name: simple-ai-benchmarking
+# File Name: dummy_workload.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""A fake benchmark run that prints a believable console over a few seconds.
+
+This stands in for a real SAIB benchmark when exercising the live-log streaming
+path locally (see ``tools/local_stream_demo.py``): tee its output to a file and
+point ``saib-logship`` at that file. It prints to both stdout and stderr, flushes
+each line, and sleeps between lines so a tailing shipper observes incremental
+growth -- exactly like an actual pod's console.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+
+def emit(text: str, *, err: bool = False) -> None:
+    stream = sys.stderr if err else sys.stdout
+    print(text, file=stream, flush=True)
+
+
+def run(steps: int, delay: float, fail: bool) -> int:
+    emit("== installing SAIB ==")
+    time.sleep(delay)
+    emit("Collecting simple-ai-benchmarking ...")
+    emit("Successfully installed simple-ai-benchmarking")
+    emit("== loading model 'dummy/tiny-7B' ==")
+    time.sleep(delay)
+    emit("WARNING: running on CPU; numbers are illustrative only", err=True)
+
+    for i in range(1, steps + 1):
+        pct = 100 * i // steps
+        tps = 120.0 + i  # pretend tokens/sec creeps up as caches warm
+        emit(f"[step {i}/{steps}] {pct:3d}%  throughput={tps:.1f} tok/s")
+        time.sleep(delay)
+
+    if fail:
+        emit("ERROR: simulated benchmark failure (--fail)", err=True)
+        return 1
+
+    emit("== benchmark complete: mean throughput 126.5 tok/s ==")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=10, help="Number of progress lines.")
+    parser.add_argument("--delay", type=float, default=0.5, help="Seconds between lines.")
+    parser.add_argument("--fail", action="store_true", help="Exit non-zero at the end.")
+    args = parser.parse_args(argv)
+    return run(args.steps, args.delay, args.fail)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/local_stream_demo.py
+++ b/tools/local_stream_demo.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# Project Name: simple-ai-benchmarking
+# File Name: local_stream_demo.py
+# Author: Timo Leitritz
+# Copyright (C) 2024 Timo Leitritz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end local smoke test for the dashboard live-log streaming feature.
+
+It reproduces what a RunPod pod does in ``saib-runpod --debug`` -- minus RunPod
+and Docker -- entirely on localhost:
+
+    dummy_workload.py  ->  logfile  ->  saib-logship  ->  local dashboard DB
+                                                  |
+                              this script polls the read endpoint and verifies
+                              the lines actually streamed through.
+
+Typical use (two terminals)::
+
+    # terminal 1, in the ai-benchmark-database repo:
+    tools/serve_local.sh            # prints AI_BENCHMARK_DATABASE_TOKEN=...
+
+    # terminal 2, in this repo:
+    AI_BENCHMARK_DATABASE_TOKEN=<token> tools/local_stream_demo.py
+
+Or let this script boot the server too (needs the sibling DB repo + uv)::
+
+    tools/local_stream_demo.py --start-server --db-repo ../ai-benchmark-database
+
+Then open the printed live-console URL in a browser to watch it in real time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOGSHIP_MODULE = "simple_ai_benchmarking.experimental.log_shipper"
+
+
+def info(msg: str) -> None:
+    print(f"[demo] {msg}", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Optional: boot the local dashboard server from the sibling DB repo
+# --------------------------------------------------------------------------- #
+def _uv_manage(db_repo: Path) -> List[str]:
+    return [
+        "uv", "run", "--with", "django>=5.0,<6.0", "--with", "djangorestframework",
+        "python", "manage.py",
+    ]
+
+
+def start_server(db_repo: Path, host: str, port: int) -> tuple[subprocess.Popen, str]:
+    """Migrate, mint a token, and run the dev server. Returns (process, token)."""
+    base = _uv_manage(db_repo)
+    info("applying migrations ...")
+    subprocess.run(base + ["migrate", "--no-input"], cwd=db_repo, check=True)
+
+    info("minting API token ...")
+    mint = (
+        "from django.contrib.auth.models import User\n"
+        "from rest_framework.authtoken.models import Token\n"
+        "u,_ = User.objects.get_or_create(username='local')\n"
+        "t,_ = Token.objects.get_or_create(user=u)\n"
+        "print(t.key)\n"
+    )
+    out = subprocess.run(
+        base + ["shell", "-c", mint], cwd=db_repo, check=True,
+        capture_output=True, text=True,
+    )
+    token = out.stdout.strip().splitlines()[-1]
+
+    info(f"starting dev server on {host}:{port} ...")
+    proc = subprocess.Popen(
+        base + ["runserver", f"{host}:{port}", "--noreload"], cwd=db_repo
+    )
+    return proc, token
+
+
+def wait_for_server(database_url: str, timeout: float = 40.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(database_url + "/dashboard/", timeout=5) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            time.sleep(1)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Read endpoint polling (the same primitive the browser live console uses)
+# --------------------------------------------------------------------------- #
+def fetch_lines(database_url: str, run_id: str, after: int = 0) -> dict:
+    url = f"{database_url}/dashboard/api/runs/{run_id}/logs/?after={after}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.loads(resp.read().decode())
+
+
+# --------------------------------------------------------------------------- #
+# The demo run
+# --------------------------------------------------------------------------- #
+def run_demo(args: argparse.Namespace, database_url: str, token: str) -> int:
+    run_id = args.run_id or f"local-demo-{int(time.time())}"
+    workdir = Path(tempfile.mkdtemp(prefix="saib-stream-demo-"))
+    log_file = workdir / "run.log"
+    stop_file = workdir / "run.done"
+    log_file.write_text("")
+
+    console_url = f"{database_url}/dashboard/runs/{run_id}/"
+    info(f"run_id = {run_id}")
+    info(f"live console: {console_url}")
+    info("(open that URL now to watch the stream live)")
+
+    # 1) Start the shipper tailing the (currently empty) log file.
+    ship_cmd = [
+        sys.executable, "-m", LOGSHIP_MODULE, str(log_file),
+        "--run-id", run_id, "--database-url", database_url, "--token", token,
+        "--stop-file", str(stop_file), "--report", "--provider", "local",
+        "--host", "localhost", "--accelerator", "CPU",
+        "--benchmark-family", "demo", "--interval", "1",
+    ]
+    info("starting saib-logship ...")
+    shipper = subprocess.Popen(ship_cmd, cwd=REPO_ROOT)
+
+    # 2) Run the dummy workload, appending its console to the same log file.
+    work_cmd = [
+        sys.executable, str(REPO_ROOT / "tools" / "dummy_workload.py"),
+        "--steps", str(args.steps), "--delay", str(args.delay),
+    ]
+    if args.fail:
+        work_cmd.append("--fail")
+    info("running dummy workload ...")
+    with open(log_file, "a") as sink:
+        rc = subprocess.run(work_cmd, stdout=sink, stderr=subprocess.STDOUT).returncode
+    info(f"workload exited rc={rc}")
+
+    # 3) Signal completion (exit code -> completed/failed) and let the shipper drain.
+    stop_file.write_text("ok" if rc == 0 else str(rc))
+    try:
+        shipper.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        shipper.terminate()
+
+    # 4) Verify the lines made it through the server.
+    info("verifying via read endpoint ...")
+    data = fetch_lines(database_url, run_id)
+    lines = data.get("lines", [])
+    info(f"server returned {len(lines)} line(s); status={data.get('status')!r}")
+    print("------ streamed console (from the database) ------")
+    for entry in lines:
+        marker = "!" if entry["stream"] == "stderr" else " "
+        print(f"  {marker} {entry['text']}")
+    print("--------------------------------------------------")
+
+    expected_status = "failed" if args.fail else "completed"
+    ok = bool(lines) and data.get("status") == expected_status
+    if ok:
+        info(f"PASS: lines streamed and run reported as {expected_status}.")
+        info(f"Open {console_url} to view it.")
+    else:
+        info(
+            "FAIL: expected streamed lines and "
+            f"status={expected_status!r}, got {len(lines)} line(s) / "
+            f"status={data.get('status')!r}."
+        )
+    return 0 if ok else 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL", "http://127.0.0.1:8000"))
+    parser.add_argument("--token", default=os.environ.get("AI_BENCHMARK_DATABASE_TOKEN"))
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--steps", type=int, default=8)
+    parser.add_argument("--delay", type=float, default=0.4)
+    parser.add_argument("--fail", action="store_true", help="Simulate a failing run.")
+    parser.add_argument("--start-server", action="store_true", help="Boot the dashboard from --db-repo.")
+    parser.add_argument("--db-repo", default="../ai-benchmark-database")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args(argv)
+
+    database_url = args.database_url.rstrip("/")
+    token = args.token
+    server: Optional[subprocess.Popen] = None
+    try:
+        if args.start_server:
+            db_repo = Path(args.db_repo).resolve()
+            if not (db_repo / "manage.py").exists():
+                raise SystemExit(f"--db-repo has no manage.py: {db_repo}")
+            database_url = f"http://{args.host}:{args.port}"
+            server, token = start_server(db_repo, args.host, args.port)
+            if not wait_for_server(database_url):
+                raise SystemExit("server did not become ready in time")
+
+        if not token:
+            raise SystemExit(
+                "No token. Set AI_BENCHMARK_DATABASE_TOKEN (printed by "
+                "serve_local.sh) or pass --start-server."
+            )
+        return run_demo(args, database_url, token)
+    finally:
+        if server is not None:
+            info("stopping dev server ...")
+            server.terminate()
+            try:
+                server.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                server.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_fleet.sh
+++ b/tools/run_fleet.sh
@@ -9,8 +9,8 @@
 # The container image is auto-selected per GPU generation by saib-runpod:
 #   * Blackwell (B200 / RTX 5090 / RTX PRO Blackwell): torch 2.8 / CUDA 12.8 image.
 #   * Everything else (Hopper / Ada / Ampere ...): torch 2.4 / CUDA 12.4 image.
-# All pods run the full-precision default LLM set (-w 0 1). FP8/FP4 benchmarking is
-# done separately via `saib-runpod --workload vllm` (see the README), not here.
+# All pods run the full-precision default LLM set (-w 0 1). FP8/FP4 benchmarking via
+# a vLLM OpenAI endpoint is a separate, opt-in fleet: see tools/run_fleet_vllm.sh.
 #
 # Usage:
 #   export RUNPOD_API_KEY=...

--- a/tools/run_fleet_vllm.sh
+++ b/tools/run_fleet_vllm.sh
@@ -43,11 +43,11 @@ fire() {
   echo "=== launching: $* ==="
   "$RUNPOD" --capacity-wait "$CAP" \
     --workload vllm --vllm-model "$VLLM_MODEL" --vllm-precisions "$VLLM_PRECISIONS" \
-    "${EXTRA[@]}" "$@" || echo "WARN: launch failed for: $*"
+    ${EXTRA[@]+"${EXTRA[@]}"} "$@" || echo "WARN: launch failed for: $*"
 }
 
 # --- One Blackwell + one Ada card; both run bf16 + fp8 --------------------------
-fire --gpu "NVIDIA RTX PRO 4500 Blackwell"  --cloud-type SECURE   # Blackwell
-fire --gpu "NVIDIA RTX 6000 Ada Generation" --cloud-type SECURE   # Ada
+fire --gpu "NVIDIA RTX PRO 6000 Blackwell Workstation Edition" --cloud-type SECURE   # Blackwell
+fire --gpu "NVIDIA RTX 6000 Ada Generation"                    --cloud-type SECURE   # Ada
 
 echo "All launch calls issued. Pods self-terminate when done; watch the RunPod console."

--- a/tools/run_fleet_vllm.sh
+++ b/tools/run_fleet_vllm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Fire a fleet of self-terminating RunPod pods that benchmark a vLLM-served LLM over
+# its OpenAI-compatible endpoint -- one pod per GPU. This is the opt-in low-bit
+# counterpart to tools/run_fleet.sh (which runs the default CV + local-LLM set).
+#
+# Each pod (launched with `saib-runpod --workload vllm`, REST dockerStartCmd, no SSH)
+# installs SAIB torch-free, pip-installs the pinned vLLM stack, then for each requested
+# precision: serves the model with vLLM, benchmarks it through SAIB's openai-compatible
+# backend, publishes the result (served_by=vllm), and tears the server down before the
+# next precision -- so bf16 vs fp8 are apples-to-apples on the same GPU. The pod then
+# self-terminates (success, crash, or a hung step). Nothing connects back.
+#
+# vLLM brings its own torch, so every GPU uses the torch 2.8 / CUDA 12.8 image
+# (auto-selected by saib-runpod for --workload vllm). fp8 + bf16 both run on Ada
+# (SM 8.9+) and Blackwell, so the default spread covers one card of each generation.
+# fp4/NVFP4 is intentionally left out for now: it needs a pre-quantized ModelOpt
+# checkpoint (--vllm-nvfp4-model) AND a Blackwell GPU. To add it later, run a
+# Blackwell card with e.g.:
+#   VLLM_PRECISIONS=bf16,fp8,fp4 \
+#   tools/run_fleet_vllm.sh --vllm-nvfp4-model <nvfp4-repo-id> \
+#     --gpu "NVIDIA RTX PRO 6000 Blackwell Workstation Edition"
+#
+# Usage:
+#   export RUNPOD_API_KEY=...
+#   export AI_BENCHMARK_DATABASE_TOKEN=...
+#   tools/run_fleet_vllm.sh                       # default 2-GPU spread below
+#   VLLM_MODEL=... VLLM_PRECISIONS=bf16,fp8 tools/run_fleet_vllm.sh
+#   tools/run_fleet_vllm.sh --no-publish          # any extra args pass through to each pod
+set -euo pipefail
+
+: "${RUNPOD_API_KEY:?set RUNPOD_API_KEY}"
+: "${AI_BENCHMARK_DATABASE_TOKEN:?set AI_BENCHMARK_DATABASE_TOKEN}"
+
+RUNPOD="${RUNPOD:-saib-runpod}"
+CAP="${CAPACITY_WAIT:-180}"       # keep retrying thin-stock GPUs for a few minutes
+VLLM_MODEL="${VLLM_MODEL:-Qwen/Qwen2.5-7B-Instruct}"
+VLLM_PRECISIONS="${VLLM_PRECISIONS:-bf16,fp8}"   # fp4 is opt-in (Blackwell + checkpoint)
+
+# Extra args ($@) pass through to every launch (e.g. --no-publish, --vllm-nvfp4-model).
+EXTRA=("$@")
+
+fire() {
+  echo "=== launching: $* ==="
+  "$RUNPOD" --capacity-wait "$CAP" \
+    --workload vllm --vllm-model "$VLLM_MODEL" --vllm-precisions "$VLLM_PRECISIONS" \
+    "${EXTRA[@]}" "$@" || echo "WARN: launch failed for: $*"
+}
+
+# --- One Blackwell + one Ada card; both run bf16 + fp8 --------------------------
+fire --gpu "NVIDIA RTX PRO 4500 Blackwell"  --cloud-type SECURE   # Blackwell
+fire --gpu "NVIDIA RTX 6000 Ada Generation" --cloud-type SECURE   # Ada
+
+echo "All launch calls issued. Pods self-terminate when done; watch the RunPod console."


### PR DESCRIPTION
**Why:** Debug Runpod runs could report completed even when the benchmark command failed, and a transient final log-shipping failure could drop the tail of the console output.

**What:**
- Capture benchmark exit codes in the debug pod script and write them to the stop file so the log shipper reports completed vs failed correctly
- Retry final log flushing before the shipper exits, so transient failures do not silently drop the last console lines
- Share JSON POST handling between log ingestion and run status reporting
- Add tests for failed benchmark status propagation and final-flush retries

**Test:**
- python3 -m compileall -q simple_ai_benchmarking/experimental/runpod_runner.py simple_ai_benchmarking/experimental/log_shipper.py
- uv run --with pytest pytest -q tests/test_runpod_runner.py tests/test_log_shipper.py
- uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch pytest -q
- bash -n for generated debug scripts: pt, llm, vllm