### PR TITLE
fix: resolve framework version for openai-compatible served models

### DIFF
--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.17.0"
+VERSION = "0.17.1"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -466,6 +466,32 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
     def _get_ai_framework_name(self) -> str:
         return OPENAI_COMPATIBLE_BACKEND
 
+    def _get_ai_framework_version(self) -> str:
+        # For a served model the framework version is the serving engine's version.
+        # vLLM (and similar) expose GET {base_url}/version; query it once so results
+        # carry a real version. The database requires this identity field to be
+        # non-empty, so fall back to the serving-engine label rather than publish a
+        # blank that gets rejected.
+        if self.cfg.ai_framework_version:
+            return self.cfg.ai_framework_version
+        version = self._query_server_version()
+        if version:
+            return version
+        return self.cfg.served_by or OPENAI_COMPATIBLE_BACKEND
+
+    def _query_server_version(self) -> str:
+        """Best-effort ``GET {base_url}/version`` -> the engine version, or ""."""
+        session = getattr(self, "_session", None)
+        if session is None:
+            return ""
+        try:
+            resp = session.get(self.cfg.base_url.rstrip("/") + "/version", timeout=10)
+            if getattr(resp, "ok", False):
+                return str(resp.json().get("version", "") or "")
+        except Exception:  # noqa: BLE001 -- metadata is best-effort, never fatal
+            pass
+        return ""
+
     def _generate_one(self, prompt: str) -> GenerationRequestResult:
         url = self.cfg.base_url.rstrip("/") + "/v1/chat/completions"
         headers = {"Content-Type": "application/json"}

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -32,14 +32,28 @@ class FakeResponse:
         return False
 
 
+class FakeVersionResponse:
+    def __init__(self, payload, ok=True):
+        self._payload = payload
+        self.ok = ok
+
+    def json(self):
+        return self._payload
+
+
 class FakeSession:
-    def __init__(self, lines):
+    def __init__(self, lines, version="0.6.3"):
         self.lines = lines
+        self.version = version
         self.calls = []
 
     def post(self, url, **kwargs):
         self.calls.append((url, kwargs))
         return FakeResponse(self.lines)
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return FakeVersionResponse({"version": self.version})
 
 
 def _tiny_config(**overrides) -> LLMGenerationConfig:
@@ -166,6 +180,74 @@ def test_openai_compatible_generation_workload_streams_and_counts_tokens():
     assert workload._session.calls[0][1]["headers"]["Authorization"] == "Bearer token"
     assert result.bench_info.backend == OPENAI_COMPATIBLE_BACKEND
     assert result.performance.generated_tokens_per_second > 0
+
+
+def test_openai_compatible_uses_server_version_as_framework_version():
+    # Regression: vLLM/openai-compatible runs left ai_framework_version blank, which
+    # the database rejects ("This field may not be blank."). The version must be
+    # resolved from the engine's GET /version so results publish.
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="test-model",
+            served_by="vllm",
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=2,
+        )
+    )
+    workload._session = FakeSession(
+        [
+            'data: {"choices":[{"delta":{"content":"hi"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}',
+            "data: [DONE]",
+        ],
+        version="0.6.3.post1",
+    )
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert any(c[0] == "https://example.test/version" for c in workload._session.calls)
+    assert result.sw_info.ai_framework_version == "0.6.3.post1"
+
+
+def test_openai_compatible_falls_back_to_served_by_when_no_version():
+    # If the engine has no /version endpoint, the identity field must still be
+    # non-empty so the row is accepted; fall back to the serving-engine label.
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="test-model",
+            served_by="vllm",
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=2,
+        )
+    )
+
+    class NoVersionSession(FakeSession):
+        def get(self, url, **kwargs):
+            raise RuntimeError("no /version endpoint")
+
+    workload._session = NoVersionSession(
+        [
+            'data: {"choices":[{"delta":{"content":"hi"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}',
+            "data: [DONE]",
+        ]
+    )
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert result.sw_info.ai_framework_version == "vllm"
 
 
 def test_openai_compatible_reports_zero_when_server_streams_no_tokens():


### PR DESCRIPTION
**Why:** vLLM (`--backend openai-compatible`) runs left `ai_framework_version` blank, and the database requires it (identity field). Every vLLM publish was rejected with `{"ai_framework_version":["This field may not be blank."]}`, surfaced by a live fleet run.

**What:**
- `OpenAICompatibleGeneration` resolves the framework version from the serving engine's `GET {base_url}/version` (vLLM exposes it), falling back to the serving-engine label (e.g. `vllm`) so the row always publishes.
- No DB change — the non-blank constraint is correct.
- Bump version `0.17.0 → 0.17.1`.

**Test:** `uv run ... pytest -q` — full suite 113 passed, including 2 new regression tests (`/version` resolution + `served_by` fallback).