### PR TITLE
fix: fix RunPod teardown key and log dedup sequencing

### DIFF
--- a/simple_ai_benchmarking/experimental/log_shipper.py
+++ b/simple_ai_benchmarking/experimental/log_shipper.py
@@ -98,10 +98,25 @@ def post_lines(
     lines: List[str],
     token: Optional[str],
     stream: str = "stdout",
+    start_seq: Optional[int] = None,
 ) -> bool:
-    """POST a batch of lines to the ingest endpoint. Return True on a 2xx."""
+    """POST a batch of lines to the ingest endpoint. Return True on a 2xx.
+
+    When ``start_seq`` is given, each line is tagged with a monotonically
+    increasing ``seq`` (its absolute index in the shipped stream) so the server
+    can drop re-sent duplicates: a slow/timed-out POST that actually succeeded
+    server-side is retried with the *same* seqs and ignored the second time,
+    instead of storing the whole batch again (the cause of the duplicated
+    console). ``seq`` is also stable across a shipper restart (offset resets to
+    0, lines re-read from the top get their original seqs)."""
     url = database_url.rstrip("/") + LOGS_ENDPOINT
-    payload = {"run_id": run_id, "stream": stream, "lines": lines}
+    if start_seq is None:
+        payload_lines: list = lines
+    else:
+        payload_lines = [
+            {"seq": start_seq + i, "text": text} for i, text in enumerate(lines)
+        ]
+    payload = {"run_id": run_id, "stream": stream, "lines": payload_lines}
     return _post_json(url, payload, token, "ingest")
 
 
@@ -158,6 +173,10 @@ class LogShipper:
     _offset: int = field(default=0, init=False)
     _carry: str = field(default="", init=False)
     _pending: List[str] = field(default_factory=list, init=False)
+    # Absolute index of ``_pending[0]`` in the shipped stream. Carried alongside
+    # the (string) pending buffer so each line keeps a stable ``seq`` for the
+    # server's idempotent ingest, while ``_pending`` stays a plain list of text.
+    _seq_base: int = field(default=0, init=False)
 
     def _read_new_text(self) -> str:
         """Return file bytes appended since the last read, advancing the offset.
@@ -210,6 +229,9 @@ class LogShipper:
         if len(self._pending) > MAX_PENDING_LINES:
             dropped = len(self._pending) - MAX_PENDING_LINES
             self._pending = self._pending[-MAX_PENDING_LINES:]
+            # Advance the base by the dropped count so seqs stay tied to the
+            # line's absolute position even after trimming the oldest.
+            self._seq_base += dropped
             log(f"dropping {dropped} oldest buffered lines (server unreachable)")
 
     def _flush_pending(self) -> None:
@@ -218,10 +240,12 @@ class LogShipper:
         while self._pending:
             batch = self._pending[: self.batch_lines]
             if not post_lines(
-                self.database_url, self.run_id, batch, self.token, self.stream
+                self.database_url, self.run_id, batch, self.token, self.stream,
+                start_seq=self._seq_base,
             ):
                 return
             del self._pending[: len(batch)]
+            self._seq_base += len(batch)
 
     def poll_once(self, *, final: bool = False) -> None:
         """One tail pass: read new text, queue complete lines, flush to server."""

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -259,9 +259,13 @@ cleanup() {
   [ "$SAIB_TERMINATED" = "1" ] && return
   SAIB_TERMINATED=1
   echo "== SAIB self-terminating pod ${RUNPOD_POD_ID} =="
+  # Use SAIB_RUNPOD_API_KEY, NOT RUNPOD_API_KEY: RunPod reserves the RUNPOD_*
+  # namespace and auto-injects its own *pod-scoped* RUNPOD_API_KEY into every
+  # container, which shadows the full-access key we set and yields HTTP 403 on
+  # the account-level DELETE. The full key is passed under the unreserved name.
   # python is present in all pytorch images, so teardown needs no curl.
-  python -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" \
-  || python3 -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" || true
+  python -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['SAIB_RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" \
+  || python3 -c "import urllib.request,os; r=urllib.request.Request('https://rest.runpod.io/v1/pods/'+os.environ['RUNPOD_POD_ID'],method='DELETE',headers={'Authorization':'Bearer '+os.environ['SAIB_RUNPOD_API_KEY']}); urllib.request.urlopen(r,timeout=30)" || true
   # Block so the container does NOT exit and get auto-restarted by RunPod before the
   # DELETE takes effect -- an exited container is restarted and the whole benchmark
   # re-runs in a loop (duplicate rows + runaway billing).
@@ -584,7 +588,10 @@ def rest_call(method: str, path: str, key: str, body: Optional[dict] = None) -> 
 
 
 def build_pod_body(cfg: Config, script: str) -> dict:
-    env = {"RUNPOD_API_KEY": cfg.api_key}
+    # NOT "RUNPOD_API_KEY": RunPod reserves the RUNPOD_* env namespace and injects
+    # its own pod-scoped key, which would shadow this full-access key and make the
+    # self-terminate DELETE fail with 403. The trap reads SAIB_RUNPOD_API_KEY.
+    env = {"SAIB_RUNPOD_API_KEY": cfg.api_key}
     # The DB token is needed to publish results and/or to stream debug logs.
     if cfg.publish or cfg.debug:
         env["AI_BENCHMARK_DATABASE_TOKEN"] = cfg.db_token or ""

--- a/tests/test_log_shipper.py
+++ b/tests/test_log_shipper.py
@@ -66,7 +66,7 @@ def test_poll_once_ships_complete_lines(tmp_path, monkeypatch):
     sent = []
     monkeypatch.setattr(
         ls, "post_lines",
-        lambda url, rid, lines, token, stream: sent.append(list(lines)) or True,
+        lambda url, rid, lines, token, stream, start_seq=None: sent.append(list(lines)) or True,
     )
     log_file.write_text("a\nb\nhalf")
     shipper.poll_once()
@@ -80,7 +80,7 @@ def test_poll_once_keeps_pending_on_failure_then_retries(tmp_path, monkeypatch):
     outcomes = [False, True]
     sent = []
 
-    def fake_post(url, rid, lines, token, stream):
+    def fake_post(url, rid, lines, token, stream, start_seq=None):
         sent.append(list(lines))
         return outcomes.pop(0)
 
@@ -91,6 +91,56 @@ def test_poll_once_keeps_pending_on_failure_then_retries(tmp_path, monkeypatch):
     shipper.poll_once()           # retries the same lines, succeeds
     assert shipper._pending == []
     assert sent == [["a", "b"], ["a", "b"]]
+
+
+def test_flush_tags_lines_with_monotonic_seq(tmp_path, monkeypatch):
+    # Each line carries its absolute index as ``start_seq`` so the server can
+    # drop re-sent duplicates. Seqs must keep counting up across batches.
+    shipper, log_file = _shipper(tmp_path, batch_lines=2)
+    seqs = []
+    monkeypatch.setattr(
+        ls, "post_lines",
+        lambda url, rid, lines, token, stream, start_seq=None: seqs.append(start_seq) or True,
+    )
+    log_file.write_text("a\nb\nc\nd\ne\n")
+    shipper.poll_once()
+    assert seqs == [0, 2, 4]  # batches of 2 -> base advances by the batch size
+
+
+def test_failed_batch_is_retried_with_same_seq(tmp_path, monkeypatch):
+    # A batch that fails (e.g. a timed-out-but-stored POST) must be re-sent with
+    # the *same* start_seq, so the server recognises and ignores the duplicate.
+    shipper, log_file = _shipper(tmp_path)
+    outcomes = [False, True]
+    seqs = []
+
+    def fake_post(url, rid, lines, token, stream, start_seq=None):
+        seqs.append(start_seq)
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(ls, "post_lines", fake_post)
+    log_file.write_text("a\nb\n")
+    shipper.poll_once()  # fails -> seq 0
+    shipper.poll_once()  # retries the SAME lines -> still seq 0
+    assert seqs == [0, 0]
+    assert shipper._seq_base == 2  # advanced only after the successful send
+
+
+def test_post_lines_tags_payload_with_seq(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = req.data.decode()
+        return _FakeResp(201)
+
+    monkeypatch.setattr(ls.urllib.request, "urlopen", fake_urlopen)
+    assert post_lines("http://db", "r1", ["x", "y"], "tok", start_seq=5) is True
+    import json as _json
+    payload = _json.loads(captured["body"])
+    assert payload["lines"] == [
+        {"seq": 5, "text": "x"},
+        {"seq": 6, "text": "y"},
+    ]
 
 
 def test_pending_buffer_is_bounded(tmp_path, monkeypatch):
@@ -111,7 +161,7 @@ def test_final_flush_retries_tail_before_giving_up(tmp_path, monkeypatch):
     outcomes = [False, False, True]
     sent = []
 
-    def fake_post(url, rid, lines, token, stream):
+    def fake_post(url, rid, lines, token, stream, start_seq=None):
         ok = outcomes.pop(0)
         if ok:
             sent.append(list(lines))


### PR DESCRIPTION
**Why:** RunPod debug logs could be duplicated when timed-out POSTs were stored server-side and retried, and self-termination could fail when RunPod shadowed the API key env var.
**What:**
- Send stable per-line log sequence numbers so the dashboard can deduplicate retries.
- Use SAIB_RUNPOD_API_KEY for pod self-termination to avoid RunPod's reserved env namespace.
- Add focused log shipper tests for sequence tagging and retry stability.
**Test:** python3 -m compileall simple_ai_benchmarking tests; uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo pytest tests/test_runpod_runner.py tests/test_log_shipper.py -q