### PR TITLE
fix: pass debug args through CV fleet script

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Useful flags: `--workload pt|llm|vllm|both` (default `both`; `vllm` is standalon
 ```bash
 export RUNPOD_API_KEY=...  AI_BENCHMARK_DATABASE_TOKEN=...
 tools/run_fleet.sh                       # default 5-GPU spread
+tools/run_fleet.sh --debug               # also stream live logs to /dashboard/
 ```
 
 ## Hardware Acceleration for PyTorch and TensorFlow

--- a/tools/run_fleet.sh
+++ b/tools/run_fleet.sh
@@ -16,6 +16,8 @@
 #   export RUNPOD_API_KEY=...
 #   export AI_BENCHMARK_DATABASE_TOKEN=...
 #   tools/run_fleet.sh                 # the default 5-GPU spread below
+#   tools/run_fleet.sh --debug         # stream live pod logs to the dashboard
+#   tools/run_fleet.sh --no-publish    # any extra args pass through to each pod
 set -euo pipefail
 
 : "${RUNPOD_API_KEY:?set RUNPOD_API_KEY}"
@@ -24,7 +26,15 @@ set -euo pipefail
 RUNPOD="${RUNPOD:-saib-runpod}"
 CAP="${CAPACITY_WAIT:-180}"     # keep retrying thin-stock GPUs for a few minutes
 
-fire() { echo "=== launching: $* ==="; "$RUNPOD" --capacity-wait "$CAP" "$@" || echo "WARN: launch failed for: $*"; }
+# Extra args ($@) pass through to every launch (e.g. --debug, --no-publish,
+# --database-url). Use --debug to stream each pod's CV/LLM console to the
+# dashboard live-log view.
+EXTRA=("$@")
+
+fire() {
+  echo "=== launching: $* ==="
+  "$RUNPOD" --capacity-wait "$CAP" ${EXTRA[@]+"${EXTRA[@]}"} "$@" || echo "WARN: launch failed for: $*"
+}
 
 # --- Blackwell: torch 2.8 image auto-selected by saib-runpod (default LLM set) --
 fire --gpu "NVIDIA B200"               --cloud-type SECURE


### PR DESCRIPTION
**Why:** The vLLM fleet script could pass --debug through to stream pod logs to the dashboard, but the default CV/LLM fleet script required a RUNPOD wrapper workaround.
**What:**
- Pass extra CLI args through from tools/run_fleet.sh to every saib-runpod launch.
- Document tools/run_fleet.sh --debug for live dashboard log streaming.
**Test:** bash -n tools/run_fleet.sh tools/run_fleet_vllm.sh