### PR TITLE
chore: point default database URL to benchmarks.timoleitritz.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple application to quickly run tests on a variety of hardware and software for AI workloads, to get an intuition on the performance. No downloading of big datasets and only a few dependencies. For more sophisticated and complex benchmarking, I recommend to use [MLPerf Benchmarks](https://mlcommons.org/benchmarks/). 
 
-Visit [timoillusion.pythonanywhere.com/benchmarks](https://timoillusion.pythonanywhere.com/benchmarks) to see current benchmark database.
+Visit [benchmarks.timoleitritz.dev/benchmarks](https://benchmarks.timoleitritz.dev/benchmarks) to see current benchmark database.
 
 I develop this application in my free time as a hobby.
 
@@ -146,7 +146,7 @@ Common options (see `saib-llm -h` for the full list):
 
 Currently results can only published by authenticated users, but user creation is manually handled currently. Contact me if you want to publish results.
 
-To publish results to [timoillusion.pythonanywhere.com/benchmarks](https://timoillusion.pythonanywhere.com/benchmarks), execute these commands:
+To publish results to [benchmarks.timoleitritz.dev/benchmarks](https://benchmarks.timoleitritz.dev/benchmarks), execute these commands:
 
 ```bash
 export AI_BENCHMARK_DATABASE_TOKEN=YOUR_TOKEN  
@@ -175,7 +175,7 @@ export AI_BENCHMARK_DATABASE_TOKEN=YOUR_TOKEN
 saib-pub-llm llm_results.csv
 ```
 
-Check [timoillusion.pythonanywhere.com/benchmarks](https://timoillusion.pythonanywhere.com/benchmarks) for the results.
+Check [benchmarks.timoleitritz.dev/benchmarks](https://benchmarks.timoleitritz.dev/benchmarks) for the results.
 
 ### Registering benchmark profiles
 

--- a/simple_ai_benchmarking/database.py
+++ b/simple_ai_benchmarking/database.py
@@ -317,7 +317,7 @@ def build_publish_parser(description: str) -> argparse.ArgumentParser:
     parser.add_argument(
         "--database-url",
         type=str,
-        default="https://timoillusion.pythonanywhere.com",
+        default="https://benchmarks.timoleitritz.dev",
         help="The URL of the AI Benchmark Database.",
     )
     parser.add_argument(
@@ -588,7 +588,7 @@ def register_profiles_cli():
     parser.add_argument(
         "--database-url",
         type=str,
-        default="https://timoillusion.pythonanywhere.com",
+        default="https://benchmarks.timoleitritz.dev",
         help="The URL of the AI Benchmark Database.",
     )
     parser.add_argument(

--- a/simple_ai_benchmarking/entrypoints.py
+++ b/simple_ai_benchmarking/entrypoints.py
@@ -79,7 +79,7 @@ class BenchmarkDispatcher:
         parser.add_argument("-t", "--token", default=None)
         parser.add_argument(
             "--database-url",
-            default="https://timoillusion.pythonanywhere.com",
+            default="https://benchmarks.timoleitritz.dev",
             help="The URL of the AI Benchmark Database.",
         )
         return parser

--- a/simple_ai_benchmarking/experimental/log_shipper.py
+++ b/simple_ai_benchmarking/experimental/log_shipper.py
@@ -55,7 +55,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-DEFAULT_DATABASE_URL = "https://timoillusion.pythonanywhere.com"
+DEFAULT_DATABASE_URL = "https://benchmarks.timoleitritz.dev"
 LOGS_ENDPOINT = "/dashboard/api/runs/logs/"
 REPORT_ENDPOINT = "/dashboard/api/runs/report/"
 

--- a/simple_ai_benchmarking/experimental/runpod_runner.py
+++ b/simple_ai_benchmarking/experimental/runpod_runner.py
@@ -71,7 +71,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 REST_BASE = "https://rest.runpod.io/v1"
-DEFAULT_DATABASE_URL = "https://timoillusion.pythonanywhere.com"
+DEFAULT_DATABASE_URL = "https://benchmarks.timoleitritz.dev"
 
 # Image per GPU generation.
 #  - torch 2.4 / CUDA 12.4 works for everything up to Hopper (sm_90) and is widely

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -145,7 +145,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("-t", "--token", default=None)
     parser.add_argument(
         "--database-url",
-        default="https://timoillusion.pythonanywhere.com",
+        default="https://benchmarks.timoleitritz.dev",
         help="The URL of the AI Benchmark Database.",
     )
     return parser.parse_args()

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -154,7 +154,7 @@ class TestPublishDatabase(unittest.TestCase):
         self.assertEqual(args.token, "tok")
         self.assertTrue(args.non_interactive)
         self.assertEqual(
-            args.database_url, "https://timoillusion.pythonanywhere.com"
+            args.database_url, "https://benchmarks.timoleitritz.dev"
         )
 
     def test_enrich_benchmark_data_roundtrips_non_interactively(self):
@@ -199,7 +199,7 @@ class TestPublishDatabase(unittest.TestCase):
                 
                 mock_args.return_value = MagicMock(
                     results_csv_path=csv_path,
-                    database_url="https://timoillusion.pythonanywhere.com",
+                    database_url="https://benchmarks.timoleitritz.dev",
                     token="test_token",
                     user=None,
                     password=None


### PR DESCRIPTION
**Why:** The benchmark database moved off PythonAnywhere to its own domain, benchmarks.timoleitritz.dev.

**What:**
- Update the default `--database-url` and `DEFAULT_DATABASE_URL` across the CLI, publishing, log shipper, and RunPod runner.
- Update README links and the `test_publish` default-URL assertions.
- Request paths (`/benchmarks/...`) are unchanged — only the host swapped.

**Test:** `python3 -m compileall simple_ai_benchmarking tests`; `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo pytest -q tests/test_publish.py` — 14 passed.