### PR TITLE
refactor: resize default LLM benchmark shape to fit ~8GB, bump spec to 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Four backends are supported — two self-contained local PyTorch backends and tw
   saib-llm --backend ollama --model llama3
   ```
 
-The benchmark performs configurable warmup and measured requests (optionally concurrent), repeats the measurement and averages the result, and reports prompt, generated, and total tokens per second, time to first token, and total duration. Each repetition runs in an isolated process. Results are written to `llm_results.csv` (and `.xlsx` if `openpyxl` is installed).
+The benchmark performs configurable warmup and measured requests (optionally concurrent), repeats the measurement and averages the result, and reports generated and total tokens per second, time to first token, and total duration. Each repetition runs in an isolated process. Results are written to `llm_results.csv` (and `.xlsx` if `openpyxl` is installed).
+
+The local-backend defaults are sized to fit an ~8 GB accelerator (targeting roughly 6 GB peak so the device is well used). Peak memory is driven by the simple-transformer backend, which has no KV cache and computes full-vocab logits every decode step, so it scales with `concurrency`, `--prompt-tokens` and `--generated-tokens`; raise those to use a bigger GPU, or lower them (or pick one backend with `-w`) on smaller/Apple-silicon devices.
 
 Common options (see `saib-llm -h` for the full list):
 
@@ -133,8 +135,8 @@ Common options (see `saib-llm -h` for the full list):
 - `--requests` / `--warmup-requests` — number of measured / warmup requests (default `32` / `2`)
 - `--repetitions` — number of times the measurement is repeated and averaged (default `3`); for paid HTTP endpoints, lower this to reduce cost
 - `--concurrency` — for HTTP backends (`openai-compatible`, `ollama`), the number of in-flight concurrent requests; for the local PyTorch backends, the batch size processed in a single batched forward pass (default `8`)
-- `--prompt-tokens` / `--generated-tokens` — prompt and generation lengths (default `2048` / `256`)
-- `--context-length` — model context window (default `4096`)
+- `--prompt-tokens` / `--generated-tokens` — prompt and generation lengths (default `1024` / `256`)
+- `--context-length` — model context window (default `2048`)
 - `--device` — torch device for the local backends, e.g. `cpu`, `cuda`, `mps` (default `cpu`)
 - `--compute-precision` — for `huggingface-causal`, applied to the model as a plain dtype cast: `FP32`/`FP16`/`BF16` (default BF16). Low-bit (`FP8`/`FP4`) is not supported locally — use a serving engine via `openai-compatible`. Recorded as metadata for the HTTP backends
 - `--quantization` — recorded as metadata (e.g. `fp8`/`nvfp4` for a vLLM server benchmarked over `openai-compatible`); `none` by default. Not applied locally

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -26,7 +26,11 @@ SPEC_VERSION = "2.1"
 # the model (vllm / ollama / pytorch / openai) is now part of the benchmark
 # identity, so results are grouped per engine even when they share the
 # openai-compatible protocol. 2.3 results carry fresh profile hashes.
-LLM_SPEC_VERSION = "2.3"
+# Bumped 2.3 -> 2.4 when the portable default benchmark shape was resized to fit an
+# ~8 GB accelerator (prompt 2048 -> 1024, context 4096 -> 2048; other knobs
+# unchanged). The default profile id therefore changes, so 2.4 results carry fresh
+# profile hashes and never mix with the heavier 2.3 default shape.
+LLM_SPEC_VERSION = "2.4"
 
 CV_RUNNER_ID = "saib.cv.classification.v2"
 LLM_RUNNER_ID = "saib.llm.generation.v2"

--- a/simple_ai_benchmarking/llm_generation.py
+++ b/simple_ai_benchmarking/llm_generation.py
@@ -98,16 +98,24 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--base-url", default=None)
     parser.add_argument("--model", default="SimpleTransformerLM")
-    # Defaults put real load on the device: for the local backends concurrency is
-    # the batch size of one forward pass, so concurrency=8 / requests=32 exercises
-    # batched prefill+decode rather than a single-sequence trickle.
+    # Defaults put real load on the device while fitting an ~8 GB accelerator
+    # (targeting ~6 GB peak so the card is well used, not maxed). For the local
+    # backends concurrency is the batch size of one forward pass, so concurrency=8
+    # / requests=32 exercises batched prefill+decode. Peak memory is driven by the
+    # simple-transformer backend, which has no KV cache: it recomputes the full
+    # forward each decode step over the whole sequence, with logits across the full
+    # vocab, so memory ~ concurrency * seq * vocab. The sequence length (prompt
+    # 1024 / context 2048) is half the earlier default to keep that peak inside
+    # 8 GB; note MPS over-reserves, so on Apple silicon prefer fewer requests or a
+    # single backend via -w. HTTP backends batch server-side -- raise concurrency
+    # there for a heavier serving load test.
     parser.add_argument("--requests", type=int, default=32)
     parser.add_argument("--warmup-requests", type=int, default=2)
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--concurrency", type=int, default=8)
-    parser.add_argument("--prompt-tokens", type=int, default=2048)
+    parser.add_argument("--prompt-tokens", type=int, default=1024)
     parser.add_argument("--generated-tokens", type=int, default=256)
-    parser.add_argument("--context-length", type=int, default=4096)
+    parser.add_argument("--context-length", type=int, default=2048)
     parser.add_argument("--timeout-s", type=float, default=120.0)
     parser.add_argument("--api-key", default=None)
     parser.add_argument("--api-key-env", default="OPENAI_API_KEY")

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -320,7 +320,7 @@ def test_generation_workload_result_is_exportable():
     row = logger.to_dataframe().iloc[0].to_dict()
 
     assert row["bench_info_benchmark_family"] == "llm"
-    assert row["bench_info_benchmark_spec_version"] == "2.3"
+    assert row["bench_info_benchmark_spec_version"] == "2.4"
     assert row["bench_info_benchmark_payload_hash"]
     # The local PyTorch backend records its engine as "pytorch".
     assert row["bench_info_serving_engine"] == "pytorch"


### PR DESCRIPTION
**Why:** The portable local-backend defaults (`prompt 2048` / `context 4096`) drove peak memory past what fits an 8 GB accelerator. The simple-transformer backend has no KV cache and computes full-vocab logits every decode step, so peak memory scales with `concurrency × seq × vocab` — the long sequence was the problem.

**What:**
- Halve the sequence: `--prompt-tokens` 2048→1024, `--context-length` 4096→2048 (targets ~6 GB peak so an 8 GB card is well used). Batching unchanged (concurrency 8 / requests 32 / gen 256 / warmup 2 / reps 3).
- Bump `LLM_SPEC_VERSION` 2.3→2.4: the default profile id changes, so 2.4 results carry fresh profile hashes and never mix with the heavier 2.3 default shape.
- README: update the default lines, add a memory-sizing note, and fix a stale "prompt … tokens per second" mention left from the metric drop (#57).
- Update the spec-version assertion in `tests/test_llm_workload.py`.

**Test:** `python3 -m compileall simple_ai_benchmarking tests`; `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q tests/test_llm_workload.py tests/test_benchmark_metadata.py tests/test_publish.py` — 35 passed. Verified parsed CLI defaults (`prompt 1024 / ctx 2048`) and `LLM_SPEC_VERSION == 2.4`.

**Note:** Memory estimate (~4–6 GB) is for an 8 GB CUDA card; MPS over-reserves, so on Apple silicon prefer fewer requests or a single backend via `-w`.