### PR TITLE
chore: revert LLM spec bump, version the default change, document versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,23 @@ Merge strategy: squash and merge only.
 
 Agent workflow: when a feature branch is ready, draft the PR title and body in the format above, show them to the user for confirmation, and only then open the PR via `gh pr create`. If `gh` is unavailable, print the exact title and body the user should paste, plus the GitHub compare URL.
 
+## Versioning
+
+There are three independent version axes. They serve different jobs — do not conflate them.
+
+**Package version (`VERSION` in `version_and_metadata.py`) + git tag — traceability.**
+Recorded on every result as `benchmark_version` (plus `benchmark_commit_id`). It is part of `payload_hash` (dedup) but **not** of any grouping hash (`profile_hash`/`config_hash`/`runner_hash`), so it never fragments comparisons — identical configs stay comparable across releases. Bump it for any user-visible behavior change (new/changed defaults, new flags, bug fixes that change output, dependency-driven behavior changes) following SemVer: patch for behavior tweaks/fixes, minor for new backwards-compatible features, major for breaking CLI/API changes. After the PR merges to `main`, tag it: `git tag -a vX.Y.Z -m "<summary>" && git push origin vX.Y.Z`.
+
+**Spec version (`SPEC_VERSION` / `LLM_SPEC_VERSION`) — methodology and identity schema. Rare and load-bearing.**
+It is hashed into the profile, so bumping it deliberately fragments results (old and new no longer group together). Bump it **only** when either:
+- the *meaning of the numbers changes for an unchanged config* (e.g. thread-pool caps that alter measured throughput, a changed TTFT/token-counting definition), or
+- the *profile/identity schema changes* (an identity dimension is added or removed, e.g. `serving_engine`).
+
+Do **not** bump the spec for: changing a default value (the profile already hashes shape — prompt/generated/context/concurrency — so a new default shape is a new profile automatically), adding/removing a reported result column (changes `payload_hash` only), refactors, or fixes that don't change measured numbers. Those are covered by the package version + commit id. When you do bump, add a comment documenting why (the existing history in `benchmark_metadata.py` is the model).
+
+**Runner id/manifest (`*_RUNNER_ID`, `build_runner_hash`) — implementation contract.**
+Bump the `.vN` runner id (or `runner_manifest_version`) only when the runner implementation changes in a way that should fragment results independently of spec/config. This is rarer still.
+
 ## Push Rules
 
 Commits, pushes, and PR merges always require explicit user confirmation, even in full auto mode. Never run `git commit`, `git push`, `gh pr merge`, or equivalent merge/push commands until the user has confirmed that exact action.

--- a/simple_ai_benchmarking/benchmark_metadata.py
+++ b/simple_ai_benchmarking/benchmark_metadata.py
@@ -26,11 +26,13 @@ SPEC_VERSION = "2.1"
 # the model (vllm / ollama / pytorch / openai) is now part of the benchmark
 # identity, so results are grouped per engine even when they share the
 # openai-compatible protocol. 2.3 results carry fresh profile hashes.
-# Bumped 2.3 -> 2.4 when the portable default benchmark shape was resized to fit an
-# ~8 GB accelerator (prompt 2048 -> 1024, context 4096 -> 2048; other knobs
-# unchanged). The default profile id therefore changes, so 2.4 results carry fresh
-# profile hashes and never mix with the heavier 2.3 default shape.
-LLM_SPEC_VERSION = "2.4"
+#
+# NOTE: the spec version tracks *methodology and identity-schema* changes, not
+# configuration defaults. Changing a default shape (e.g. prompt/context length) is
+# already captured by the profile (which hashes prompt/generated/context/concurrency)
+# and by the recorded code version (benchmark_version + commit_id), so it does NOT
+# warrant a spec bump. See the "Versioning" section in AGENTS.md.
+LLM_SPEC_VERSION = "2.3"
 
 CV_RUNNER_ID = "saib.cv.classification.v2"
 LLM_RUNNER_ID = "saib.llm.generation.v2"
@@ -119,12 +121,17 @@ def build_llm_profile(
 def build_llm_profile_id(profile: Mapping[str, Any]) -> str:
     # serving_engine is part of the id so e.g. a vLLM-served and an OpenAI-served
     # run over the same openai-compatible protocol get distinct, readable ids.
+    # The version suffix is derived from the spec major (like build_cv_profile_id)
+    # rather than hardcoded, so a future major spec bump is reflected in the id and
+    # never mislabels a new-spec profile as v2. For all 2.x specs this is "v2", so
+    # existing profile ids are unchanged.
     engine = profile.get("serving_engine") or "na"
+    spec_major = str(profile["benchmark_spec_version"]).split(".", 1)[0]
     return (
         f"llm_{profile['backend_protocol_class']}_{engine}_{profile['model']}_"
         f"{profile['benchmark_type']}_p{profile['prompt_token_target']}_"
         f"g{profile['generated_token_target']}_ctx{profile['context_length']}_"
-        f"c{profile['concurrency']}_v2"
+        f"c{profile['concurrency']}_v{spec_major}"
     ).lower().replace(" ", "_")
 
 

--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.17.1"
+VERSION = "0.17.2"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/tests/test_benchmark_metadata.py
+++ b/tests/test_benchmark_metadata.py
@@ -1,6 +1,7 @@
 import pytest
 
 from simple_ai_benchmarking.benchmark_metadata import (
+    LLM_SPEC_VERSION,
     SPEC_VERSION,
     build_cv_profile,
     build_cv_profile_id,
@@ -137,6 +138,25 @@ def test_cv_profile_id_matches_spec_major_version():
 
     spec_major = SPEC_VERSION.split(".", 1)[0]
     assert build_cv_profile_id(profile).endswith(f"_v{spec_major}")
+
+
+def test_llm_profile_id_matches_spec_major_version():
+    # The version suffix is derived from the spec major, not hardcoded, so a future
+    # major spec bump is reflected in the id (mirrors build_cv_profile_id).
+    profile = build_llm_profile(
+        backend="llama.cpp",
+        model="Meta-Llama-3-8B",
+        benchmark_type="inference",
+        compute_precision="FP16",
+        quantization="Q4_K_M",
+        context_length=4096,
+        prompt_tokens=128,
+        generated_tokens=256,
+        concurrency=1,
+    )
+
+    spec_major = LLM_SPEC_VERSION.split(".", 1)[0]
+    assert build_llm_profile_id(profile).endswith(f"_v{spec_major}")
 
 
 def test_llm_profile_hash_changes_for_comparability_parameters():

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -320,7 +320,7 @@ def test_generation_workload_result_is_exportable():
     row = logger.to_dataframe().iloc[0].to_dict()
 
     assert row["bench_info_benchmark_family"] == "llm"
-    assert row["bench_info_benchmark_spec_version"] == "2.4"
+    assert row["bench_info_benchmark_spec_version"] == "2.3"
     assert row["bench_info_benchmark_payload_hash"]
     # The local PyTorch backend records its engine as "pytorch".
     assert row["bench_info_serving_engine"] == "pytorch"


### PR DESCRIPTION
**Why:** The default-shape change (#59) bumped `LLM_SPEC_VERSION` 2.3→2.4, but that wasn't warranted. The spec version is hashed into the profile and is meant to gate *methodology / identity-schema* changes; a default value is neither. The new shape is already a distinct profile (the profile hashes prompt/generated/context/concurrency), and "which code ran" is recorded as `benchmark_version` + `commit_id` — which sit outside the grouping hashes, so they trace without fragmenting. Keeping the bump would instead fragment methodologically-identical runs across the version boundary.

**What:**
- Revert `LLM_SPEC_VERSION` 2.4 → 2.3 (no 2.4 data was ever published).
- Fix `build_llm_profile_id`: derive the `_v<major>` suffix from the spec version (like `build_cv_profile_id`) instead of hardcoding `_v2`, so a future *major* spec bump is reflected in the id and can't mislabel a new-spec profile as v2. No change for any 2.x spec (still `_v2`). Add an LLM analog of the CV spec-major id test.
- Bump package version 0.17.1 → 0.17.2 for the default-shape behavior change from #59 (tagged `v0.17.2` after merge).
- Add a **Versioning** section to `AGENTS.md` documenting the three axes (package version+tag = traceability; spec version = methodology/identity-schema, rare; runner id = implementation contract) and when to bump each.

**Test:** `python3 -m compileall simple_ai_benchmarking tests`; `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q tests/test_benchmark_metadata.py tests/test_llm_workload.py tests/test_publish.py` — 36 passed (incl. new `test_llm_profile_id_matches_spec_major_version`). Verified `VERSION==0.17.2`, `LLM_SPEC_VERSION==2.3`, profile_id ends `_v2`.