### PR TITLE
test: harden profile-id spec-major tests to verify derivation

### DIFF
--- a/tests/test_benchmark_metadata.py
+++ b/tests/test_benchmark_metadata.py
@@ -138,6 +138,10 @@ def test_cv_profile_id_matches_spec_major_version():
 
     spec_major = SPEC_VERSION.split(".", 1)[0]
     assert build_cv_profile_id(profile).endswith(f"_v{spec_major}")
+    # Verify the suffix is *derived* from the spec version, not hardcoded to the
+    # current major: a different major must change the suffix accordingly.
+    bumped = dict(profile, benchmark_spec_version="9.7")
+    assert build_cv_profile_id(bumped).endswith("_v9")
 
 
 def test_llm_profile_id_matches_spec_major_version():
@@ -157,6 +161,11 @@ def test_llm_profile_id_matches_spec_major_version():
 
     spec_major = LLM_SPEC_VERSION.split(".", 1)[0]
     assert build_llm_profile_id(profile).endswith(f"_v{spec_major}")
+    # Verify the suffix is *derived* from the spec version, not hardcoded to the
+    # current major: a different major must change the suffix accordingly. This is
+    # what catches a regression back to a hardcoded `_v2`.
+    bumped = dict(profile, benchmark_spec_version="9.7")
+    assert build_llm_profile_id(bumped).endswith("_v9")
 
 
 def test_llm_profile_hash_changes_for_comparability_parameters():


### PR DESCRIPTION
**Why:** The spec-major id tests (`test_llm_profile_id_matches_spec_major_version`, `test_cv_profile_id_matches_spec_major_version`) derived the expected `_v<major>` suffix from the same `*_SPEC_VERSION` constant the code uses. With the current major being `2`, they passed even if the suffix were hardcoded to `_v2` — so they did not actually guard the "derive, don't hardcode" behavior the recent `build_llm_profile_id` fix introduced. (Found in code review.)

**What:**
- Add a second assertion to both tests using a profile with `benchmark_spec_version="9.7"`, expecting the id to end `_v9`. A regression back to a hardcoded `_v2` now fails the test.

**Test:** `uv run --with pytest --with pandas --with tabulate --with loguru --with requests --with py-cpuinfo --with torch --with transformers pytest -q tests/test_benchmark_metadata.py` — 12 passed. Test-only change; no production code touched.