### PR TITLE
fix: Record vLLM model parameter metadata

### DIFF
--- a/simple_ai_benchmarking/version_and_metadata.py
+++ b/simple_ai_benchmarking/version_and_metadata.py
@@ -1,2 +1,2 @@
-VERSION = "0.17.2"
+VERSION = "0.17.3"
 REPO_URL = "https://github.com/TimoIllusion/simple-ai-benchmarking"

--- a/simple_ai_benchmarking/workloads/llm_workload.py
+++ b/simple_ai_benchmarking/workloads/llm_workload.py
@@ -39,6 +39,7 @@ PYTORCH_GENERATION_BACKEND = "pytorch-simple-transformer"
 HF_CAUSAL_BACKEND = "huggingface-causal"
 OPENAI_COMPATIBLE_BACKEND = "openai-compatible"
 OLLAMA_BACKEND = "ollama"
+VLLM_SERVING_ENGINE = "vllm"
 
 # Floating-point precisions applied by a plain dtype cast of the random-weight
 # model (no extra dependency). Low-bit formats (FP8/FP4/int8/int4) are not dtype
@@ -411,6 +412,11 @@ class HTTPGenerationWorkload(LLMGenerationWorkload):
 
         if getattr(self, "_session", None) is None:
             self._session = requests.Session()
+        if self.cfg.model_params == 0:
+            self.cfg.model_params = self._resolve_served_model_parameters()
+
+    def _resolve_served_model_parameters(self) -> int:
+        return 0
 
     def _build_prompt(self) -> str:
         # Roughly one token per simple word for backend-independent prompt targets.
@@ -464,6 +470,11 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
 
     def _get_ai_framework_name(self) -> str:
         return OPENAI_COMPATIBLE_BACKEND
+
+    def _resolve_served_model_parameters(self) -> int:
+        if self._get_serving_engine() != VLLM_SERVING_ENGINE:
+            return 0
+        return _count_huggingface_causal_lm_parameters(self.cfg.model)
 
     def _get_ai_framework_version(self) -> str:
         # For a served model the framework version is the serving engine's version.
@@ -555,6 +566,27 @@ class OpenAICompatibleGeneration(HTTPGenerationWorkload):
             if time_to_first_token_s is not None
             else duration_s,
         )
+
+
+def _count_huggingface_causal_lm_parameters(model_id: str) -> int:
+    """Best-effort architecture parameter count without allocating checkpoint weights.
+
+    vLLM exposes generation over HTTP, not a local ``nn.Module``. For Hugging Face
+    model IDs, build the causal LM skeleton on the PyTorch ``meta`` device from
+    config only and count tensor shapes. Metadata collection must never break the
+    benchmark, so unsupported architectures, missing optional dependencies, or
+    network/cache misses all fall back to 0.
+    """
+    try:
+        import torch
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        config = AutoConfig.from_pretrained(model_id)
+        with torch.device("meta"):
+            model = AutoModelForCausalLM.from_config(config)
+        return int(sum(p.numel() for p in model.parameters()))
+    except Exception:  # noqa: BLE001 -- best-effort metadata only
+        return 0
 
 
 class OllamaGeneration(HTTPGenerationWorkload):

--- a/tests/test_llm_workload.py
+++ b/tests/test_llm_workload.py
@@ -10,6 +10,7 @@ from simple_ai_benchmarking.workloads.factory import WorkloadFactory
 from simple_ai_benchmarking.workloads.llm_workload import (
     OLLAMA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
+    VLLM_SERVING_ENGINE,
     OllamaGeneration,
     OpenAICompatibleGeneration,
 )
@@ -213,6 +214,93 @@ def test_openai_compatible_uses_server_version_as_framework_version():
 
     assert any(c[0] == "https://example.test/version" for c in workload._session.calls)
     assert result.sw_info.ai_framework_version == "0.6.3.post1"
+
+
+def test_openai_compatible_vllm_resolves_model_params(monkeypatch):
+    import simple_ai_benchmarking.workloads.llm_workload as llm_workload
+
+    seen = {}
+
+    def fake_count(model_id):
+        seen["model_id"] = model_id
+        return 123456789
+
+    monkeypatch.setattr(
+        llm_workload, "_count_huggingface_causal_lm_parameters", fake_count
+    )
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="org/model",
+            served_by=VLLM_SERVING_ENGINE,
+            requests=1,
+            warmup_requests=0,
+            concurrency=1,
+            generated_tokens=2,
+        )
+    )
+    workload._session = FakeSession(
+        [
+            'data: {"choices":[{"delta":{"content":"hi"}}]}',
+            'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}',
+            "data: [DONE]",
+        ]
+    )
+    workload.setup()
+    workload.warmup()
+    workload.execute()
+    result = workload.build_result_log()
+
+    assert seen["model_id"] == "org/model"
+    assert result.bench_info.model_params == 123456789
+
+
+def test_openai_compatible_keeps_explicit_model_params(monkeypatch):
+    import simple_ai_benchmarking.workloads.llm_workload as llm_workload
+
+    def fail_if_called(model_id):
+        raise AssertionError(f"unexpected resolver call for {model_id}")
+
+    monkeypatch.setattr(
+        llm_workload, "_count_huggingface_causal_lm_parameters", fail_if_called
+    )
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="org/model",
+            served_by=VLLM_SERVING_ENGINE,
+            model_params=42,
+        )
+    )
+    workload._session = FakeSession([])
+    workload.setup()
+
+    assert workload.cfg.model_params == 42
+
+
+def test_openai_compatible_non_vllm_does_not_resolve_model_params(monkeypatch):
+    import simple_ai_benchmarking.workloads.llm_workload as llm_workload
+
+    def fail_if_called(model_id):
+        raise AssertionError(f"unexpected resolver call for {model_id}")
+
+    monkeypatch.setattr(
+        llm_workload, "_count_huggingface_causal_lm_parameters", fail_if_called
+    )
+    workload = OpenAICompatibleGeneration(
+        LLMGenerationConfig(
+            backend=OPENAI_COMPATIBLE_BACKEND,
+            base_url="https://example.test",
+            model="gpt-test",
+            served_by="openai",
+        )
+    )
+    workload._session = FakeSession([])
+    workload.setup()
+
+    assert workload.cfg.model_params == 0
 
 
 def test_openai_compatible_falls_back_to_served_by_when_no_version():


### PR DESCRIPTION
**Why:** vLLM/OpenAI-compatible LLM benchmark rows recorded model_params as 0 unless callers supplied an exact count manually.\n**What:**\n- Resolve vLLM-served Hugging Face causal LM parameter counts from config on the PyTorch meta device.\n- Preserve explicit --model-params and leave non-vLLM OpenAI-compatible backends unchanged.\n- Bump package version to 0.17.3.\n**Test:** uv run pytest tests/test_llm_workload.py -q; python3 -m compileall simple_ai_benchmarking tests